### PR TITLE
Calling check=True on agent/plugin/plugin causes 500

### DIFF
--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -134,6 +134,8 @@ class RunnableNode(ParentNode):
             values, unit = self.method(*args, **kwargs)
         except TypeError:
             values, unit = self.method()
+        except AttributeError:
+            return self.execute_plugin(*args, **kwargs)
 
         if not isinstance(values, (list, tuple)):
             values = [values]
@@ -160,7 +162,6 @@ class RunnableNode(ParentNode):
             logging.exception(exc)
 
         return {'returncode': returncode, 'stdout': stdout}
-
 
     def get_nagios_return(self, values, is_warning, is_critical):
         proper_name = self.title.replace('|', '/')

--- a/agent/listener/pluginnodes.py
+++ b/agent/listener/pluginnodes.py
@@ -36,7 +36,7 @@ class PluginNode(nodes.RunnableNode):
         except ConfigParser.NoOptionError:
             return '$plugin_name $plugin_args'
 
-    def execute_plugin(self, config):
+    def execute_plugin(self, config, *args, **kwargs):
         """Runs custom scripts that MUST be located in the scripts subdirectory
         of the executable
 


### PR DESCRIPTION
Fixed issue where a server 500 was rendered by attempting
to run a plugin and specify check=True at the same time.

https://github.com/NagiosEnterprises/ncpa/issues/17
