### PR TITLE
Adding API Authentication Back Breaks Passive Checks

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,15 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0" is_locked="false">
+    <option name="myName" value="Project Default" />
+    <option name="myLocal" value="false" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="pyOpenSSL" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="Project Default" />
+    <option name="USE_PROJECT_PROFILE" value="true" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/agent/listener/server.py
+++ b/agent/listener/server.py
@@ -17,7 +17,7 @@ import geventwebsocket
 
 __VERSION__ = '1.7.1'
 __STARTED__ = datetime.datetime.now()
-
+__INTERNAL__ = False
 
 base_dir = os.path.dirname(sys.path[0])
 
@@ -56,7 +56,10 @@ def requires_auth(f):
         ncpa_token = listener.config['iconfig'].get('api', 'community_string')
         token = request.args.get('token', None)
 
-        if session.get('logged', False) or token == ncpa_token:
+        if __INTERNAL__ is True:
+            # This is an internal call, we don't check. (Passive agent call.)
+            pass
+        elif session.get('logged', False) or token == ncpa_token:
             session['logged'] = True
         elif token is None:
             return redirect(url_for('login'))

--- a/agent/passive/ncpacheck.py
+++ b/agent/passive/ncpacheck.py
@@ -58,6 +58,7 @@ class NCPACheck(object):
         """
         logging.info("Running check: %s", self.instruction)
         api_url, api_args = self.get_api_url_from_instruction(self.instruction)
+
         response = self.run_check(api_url, api_args)
         stdout, returncode = self.handle_agent_response(response)
 
@@ -83,6 +84,7 @@ class NCPACheck(object):
 
         logging.debug("Access the API with %s", complete_api_url)
 
+        listener.server.__INTERNAL__ = True
         api_server = listener.server.listener.test_client()
 
         try:

--- a/agent/passive/nrdp.py
+++ b/agent/passive/nrdp.py
@@ -16,7 +16,6 @@ class Handler(nagioshandler.NagiosHandler):
         super(Handler, self).__init__(config, *args, **kwargs)
         listener.server.listener.config['iconfig'] = config
 
-
     @staticmethod
     def make_tag(tag_name, text='', tag_attr=None):
         """

--- a/agent/passive/test_NRDPHandler.py
+++ b/agent/passive/test_NRDPHandler.py
@@ -20,6 +20,8 @@ class TestNRDPHandler(TestCase):
         self.config.add_section('passive checks')
         self.config.set('passive checks', '%HOSTNAME%|__HOST__', '/cpu/count')
         self.config.set('passive checks', 'TESTING|TESTING', '/cpu/count')
+        self.config.add_section('api')
+        self.config.set('api', 'community_string', 'mytoken')
         self.n = nrdp(self.config)
 
     def test_make_tag(self):

--- a/agent/passive/test_nagiosHandler.py
+++ b/agent/passive/test_nagiosHandler.py
@@ -11,6 +11,8 @@ class TestNagiosHandler(TestCase):
         config.set('passive checks', '%HOSTNAME%|PING', '/cpu/percent')
         config.set('passive checks', '%hostname%|__HOST__', '/api/cpu/percent --warning 10')
         config.set('passive checks', 'localhost|CPU Load', '/api/cpu/percent?warning=10')
+        config.add_section('api')
+        config.set('api', 'community_string', 'mytoken')
         self.nh = nh(config)
 
     def test_get_commands_from_config(self):


### PR DESCRIPTION
After fixing up the test runners, I found that the passive checks
were no longer running properly as they /api had recently been
fixed to request a token. Added an **INTERNAL** variable to indicate
when an **INTERNAL** call is going on. This requires the **INTERNAL**
variable in the listener.service module to be set to True.
