### PR TITLE
Fixing --list error with no metric

### DIFF
--- a/client/CHANGELIST.md
+++ b/client/CHANGELIST.md
@@ -1,3 +1,7 @@
+0.3.3
+-----
+- Fixed issue where --list with no metric would cause an error
+
 0.3.2
 -----
 - Fixed issue where --unit would change the base unit, not the unit prefix

--- a/client/check_ncpa.py
+++ b/client/check_ncpa.py
@@ -38,7 +38,7 @@ except AttributeError:
 import shlex
 import re
 
-__VERSION__ = '0.3.2'
+__VERSION__ = '0.3.3'
 
 
 def pretty(d, indent=0, indenter=' ' * 4):
@@ -150,7 +150,11 @@ def get_host_part_from_options(options):
         metric = ''
 
     arguments = get_check_arguments_from_options(options)
-    api_address = 'https://%s:%d/api/%s/%s' % (hostname, port, metric, arguments)
+    if not metric and not arguments:
+        api_address = 'https://%s:%d/api' % (hostname, port)
+    else:
+        api_address = 'https://%s:%d/api/%s/%s' % (hostname, port, metric,
+                                                   arguments)
 
     return api_address
 
@@ -184,10 +188,10 @@ def get_arguments_from_options(options, **kwargs):
     if not options.list:
         arguments['warning'] = options.warning
         arguments['critical'] = options.critical
-        arguments['delta'] = options.delta 
+        arguments['delta'] = options.delta
         arguments['check'] = 1
         arguments['unit'] = options.units
-    
+
     if options.query_args:
         for argument in options.query_args.split(','):
             key, value = argument.split('=')


### PR DESCRIPTION
Using --list with no metric would cause an error when it should just
return the whole list. This is now fixed.