### PR TITLE
Added SSL Directive in Config

### DIFF
--- a/agent/etc/ncpa.cfg
+++ b/agent/etc/ncpa.cfg
@@ -7,6 +7,8 @@ gid = nagcmd
 logfile = var/ncpa_listener.log
 port = 5693
 pidfile = var/ncpa_listener.pid
+# Available versions: PROTOCOL SSLv2, SSLv3, TLSv1
+ssl_version = TLSv1
 
 [passive]
 uid = nagios

--- a/agent/ncpa_posix_listener.py
+++ b/agent/ncpa_posix_listener.py
@@ -12,6 +12,7 @@ import webhandler
 import listener.psapi
 import jinja2.ext  # Here for cx_Freeze import reasons, do not remove it
 import sys
+import ssl
 if 'threading' in sys.modules:
     del sys.modules['threading']
 from gevent import monkey
@@ -30,12 +31,26 @@ class Listener(ncpadaemon.Daemon):
 
             user_cert = self.config_parser.get('listener', 'certificate')
 
+            ssl_str_version = self.config_parser.get('listener',
+                                                     'ssl_version',
+                                                     'TLSv1')
+            try:
+                ssl_version = getattr(ssl, 'PROTOCOL_' + ssl_str_version)
+            except:
+                ssl_version = getattr(ssl, 'PROTOCOL_TLSv1')
+                ssl_str_version = 'TLSv1'
+            logging.info('Using SSL version %s', ssl_str_version)
+
             if user_cert == 'adhoc':
                 basepath = filename.get_dirname_file()
                 cert, key = listener.certificate.create_self_signed_cert(basepath, 'ncpa.crt', 'ncpa.key')
             else:
                 cert, key = user_cert.split(',')
-            ssl_context = {'certfile': cert, 'keyfile': key}
+            ssl_context = {
+                'certfile': cert,
+                'keyfile': key,
+                'ssl_version': ssl_version
+            }
 
             listener.server.listener.secret_key = os.urandom(24)
             http_server = WSGIServer(listener=(address, port),

--- a/agent/ncpa_windows.py
+++ b/agent/ncpa_windows.py
@@ -27,6 +27,7 @@ import listener.certificate
 import jinja2.ext
 import webhandler
 import filename
+import ssl
 from gevent import monkey
 
 monkey.patch_all(subprocess=True)
@@ -121,6 +122,13 @@ class Listener(Base):
             listener.server.listener.config_file = self.config_filename
             listener.server.listener.tail_method = listener.windowslogs.tail_method
             listener.server.listener.config['iconfig'] = self.config
+
+            try:
+                ssl_version = getattr(ssl, 'PROTOCOL_' + ssl_str_version)
+            except:
+                ssl_version = getattr(ssl, 'PROTOCOL_TLSv1')
+                ssl_str_version = 'TLSv1'
+            logging.info('Using SSL version %s', ssl_str_version)
 
             user_cert = self.config.get('listener', 'certificate')
 


### PR DESCRIPTION
Previously, SSL version were bound to "whatever PyOpenSSL" chose.
This obviously led to many exploits with SSLv3 and POODLE. This has
been changed so that now the user can enter the SSL version number
in the config file.

Currently supports is SSLv2, SSLv3 and TLSv1. The default is TLSv1
if no entry exists or if the entry that is entered does not associate
with an actual object recognized by the ssl module.