### PR TITLE
Fix Windows Delayed Start with Services

### DIFF
--- a/agent/build_resources/ncpa.nsi
+++ b/agent/build_resources/ncpa.nsi
@@ -125,6 +125,8 @@ Section ""
     nsExec::Exec '$9 /c diskperf -Y'
     nsExec::Exec '$9 /c "$INSTDIR\ncpa_listener.exe" --install ncpalistener'
     nsExec::Exec '$9 /c "$INSTDIR\ncpa_passive.exe" --install ncpapassive'
+    nsExec::Exec '$9 /c sc config ncpalistener start= delayed-auto'
+    nsExec::Exec '$9 /c sc config ncpapassive start= delayed-auto'
  
     ; ...
 SectionEnd


### PR DESCRIPTION
Have the passive and listener service default to delayed start
to avoid strange start up hangs.