### PR TITLE
adding option to print performance data where there is none for the p…

### DIFF
--- a/client/check_ncpa.py
+++ b/client/check_ncpa.py
@@ -103,6 +103,8 @@ def parse_args():
                       help='Extra query arguments to pass in the NCPA URL.')
     parser.add_option("-s", "--secure", action='store_true', default=False,
                       help='Require successful certificate verification. Does not work on Python < 2.7.9.')
+    parser.add_option("-p", "--performance", action='store_true',
+                      help='Print performance data even when there is none. Will print data matching the return code of this script')
     options, _ = parser.parse_args()
 
     if options.version:
@@ -272,7 +274,12 @@ def main():
         if options.list:
             return show_list(info_json)
         else:
-            return run_check(info_json)
+            stdout, returncode = run_check(info_json)
+            if options.performance and stdout.find("|") == -1:
+                performance = " | 'status'={};1;2;".format(returncode)
+                return "{}{}".format(stdout, performance), returncode
+            else:
+                return stdout, returncode
     except Exception, e:
         if options.debug:
             return 'The stack trace:' + traceback.format_exc(), 3


### PR DESCRIPTION
…urposes of up/down graphing

I imagine this might be a bit of an edge case and looking at how the client actually functions think this might fit a bit better in the agent itself but I can make use of this as-is now rather than in the agent later so, here it is.

The company I work for has been making use of dashboards a lot here recently and there's desire to have simple up/down items (like api/service/blah/running) show up as more than the red/green stoplights. We're also trialing nagflux and services without performance data don't end up in the database for graphing. Adding the "-p" flag to the check_ncpa.py command allows for printing of performance data when there initially isn't any based off the intended response code of the script, doesn't interfere with existing performance data being sent and allows graphing of previously ungraphable items.