### PR TITLE
Update ncpa.cfg with Windows Script File extension (.wsf)

### DIFF
--- a/agent/etc/ncpa.cfg
+++ b/agent/etc/ncpa.cfg
@@ -259,4 +259,5 @@ plugin_path = plugins/
 # Windows
 .ps1 = powershell -ExecutionPolicy Bypass -File $plugin_name $plugin_args
 .vbs = cscript $plugin_name $plugin_args //NoLogo
+.wsf = cscript $plugin_name $plugin_args //NoLogo
 .bat = cmd /c $plugin_name $plugin_args


### PR DESCRIPTION
Added Windows Script File extension (.wsf) as some plugins use files with mixed language support