### PR TITLE
Added a few pseudo devices to skip default

### DIFF
--- a/agent/etc/ncpa.cfg
+++ b/agent/etc/ncpa.cfg
@@ -27,11 +27,11 @@ check_logging_time = 30
 #
 # Excluded file system types removes these fs types from the disk metrics
 # (This is mostly only noteable on UNIX systems but also works on Windows if you need it)
-# Default: aufs,autofs,binfmt_misc,cifs,cgroup,debugfs,devpts,devtmpfs,encryptfs,
-#          efivarfs,fuse,hugelbtfs,mqueue,nfs,overlayfs,proc,pstore,rpc_pipefs,
-#          securityfs,smb,sysfs,tmpfs,tracefs
+# Default: aufs,autofs,binfmt_misc,cifs,cgroup,configfs,debugfs,devpts,devtmpfs,
+#          encryptfs,efivarfs,fuse,hugelbtfs,mqueue,nfs,overlayfs,proc,pstore,
+#          rpc_pipefs,securityfs,selinuxfs,smb,sysfs,tmpfs,tracefs
 #
-exclude_fs_types = aufs,autofs,binfmt_misc,cifs,cgroup,debugfs,devpts,devtmpfs,encryptfs,efivarfs,fuse,hugelbtfs,mqueue,nfs,overlayfs,proc,pstore,rpc_pipefs,securityfs,smb,sysfs,tmpfs,tracefs
+exclude_fs_types = aufs,autofs,binfmt_misc,cifs,cgroup,configfs,debugfs,devpts,devtmpfs,encryptfs,efivarfs,fuse,hugelbtfs,mqueue,nfs,overlayfs,proc,pstore,rpc_pipefs,securityfs,selinuxfs,smb,sysfs,tmpfs,tracefs
 
 #
 # The default unit to convert bytes (B) into if no unit is specified


### PR DESCRIPTION
Added exclude_fs_types: selinuxfs,configfs
example:
```
# egrep "selinuxfs|configfs" /etc/mtab
selinuxfs /sys/fs/selinux selinuxfs rw,relatime 0 0
configfs /sys/kernel/config configfs rw,relatime 0 0
```