### PR TITLE
IPv6 support: listen on a dual-stack IP socket by default

### DIFF
--- a/agent/build_resources/ncpa.nsi
+++ b/agent/build_resources/ncpa.nsi
@@ -144,7 +144,7 @@ Function .onInit
     ${EndIf}
 
     ; Define defaults for silent installs
-    StrCpy $bind_ip "0.0.0.0"
+    StrCpy $bind_ip "::"
     StrCpy $bind_port "5693"
     StrCpy $ssl_version "TLSv1_2"
     StrCpy $check_interval "300"

--- a/agent/build_resources/nsis_listener_options.ini
+++ b/agent/build_resources/nsis_listener_options.ini
@@ -97,7 +97,7 @@ Bottom=136
 
 [Field 12]
 Type=Text
-State=0.0.0.0
+State=::
 Left=44
 Right=122
 Top=94

--- a/agent/etc/ncpa.cfg.sample
+++ b/agent/etc/ncpa.cfg.sample
@@ -63,10 +63,10 @@ gid = nagios
 
 #
 # IP address and port number for the Listener to use for the web GUI and API
-# Default: ip = 0.0.0.0
+# Default: ip = ::
 # Default: port = 5693
 #
-ip = 0.0.0.0
+ip = ::
 port = 5693
 
 #

--- a/agent/listener/server.py
+++ b/agent/listener/server.py
@@ -522,7 +522,7 @@ def admin_global():
 @requires_admin_auth
 def admin_listener_config():
     tmp_args = { 'no_nav': True,
-                 'ip': get_config_value('listener', 'ip', '0.0.0.0'),
+                 'ip': get_config_value('listener', 'ip', '::'),
                  'port': get_config_value('listener', 'port', '5693'),
                  'uid': get_config_value('listener', 'uid', 'nagios'),
                  'gid': get_config_value('listener', 'gid', 'nagios'),

--- a/agent/listener/static/help/configuration.html
+++ b/agent/listener/static/help/configuration.html
@@ -116,8 +116,8 @@
                             <tr>
                                 <td><i class="fa fa-asterisk"></i></td>
                                 <th>ip</th>
-                                <td>0.0.0.0</td>
-                                <td>This determines what IP the service will listen on. By default, it uses the value 0.0.0.0, which means it will listen on all interfaces and all hostname references. Change this if you would like the service to listen on a specific IP or hostname.</td>
+                                <td>::</td>
+                                <td>This determines what IP the service will listen on. By default, it uses the value ::, which means it will listen on all IPv4 and IPv6 interfaces and all hostname references. Change this if you would like the service to listen on a specific IP or hostname.</td>
                             </tr>
                             <tr>
                                 <td><i class="fa fa-asterisk"></i></td>

--- a/agent/ncpa_listener.py
+++ b/agent/ncpa_listener.py
@@ -46,8 +46,8 @@ class Listener(ncpadaemon.Daemon):
             try:
                 address = self.config_parser.get('listener', 'ip')
             except Exception:
-                self.config_parser.set('listener', 'ip', '0.0.0.0')
-                address = '0.0.0.0'
+                self.config_parser.set('listener', 'ip', '::')
+                address = '::'
 
             try:
                 port = self.config_parser.getint('listener', 'port')

--- a/agent/ncpa_windows.py
+++ b/agent/ncpa_windows.py
@@ -132,8 +132,8 @@ class Listener(Base):
             try:
                 address = self.config.get('listener', 'ip')
             except Exception:
-                self.config.set('listener', 'ip', '0.0.0.0')
-                address = '0.0.0.0'
+                self.config.set('listener', 'ip', '::')
+                address = '::'
 
             try:
                 port = self.config.getint('listener', 'port')

--- a/dist/nsclient_migration/ncpa_template.txt
+++ b/dist/nsclient_migration/ncpa_template.txt
@@ -2,7 +2,7 @@
 uid = nagios 
 certificate = adhoc
 loglevel = info
-ip = 0.0.0.0
+ip = ::
 gid = nagios
 logfile = var/log/ncpa_listener.log
 port = 5693


### PR DESCRIPTION
This commit causes NCPA to listen on a dual-stack socket by default (as long as the sysctl net.ipv6.bindv6only is left at the default of false, or equivalent for non-Linux OSes). This allows for both IPv6 and Legacy IP (IPv4) support.

I didn't test all of these changes. I just tested changing 0.0.0.0 to :: in ncpa.cfg from ncpa 2.1.4 on a RHEL 7 system, and it works as expected.