### PR TITLE
Add a way to scale windows performance counters in the API

### DIFF
--- a/agent/listener/windowscounters.py
+++ b/agent/listener/windowscounters.py
@@ -55,14 +55,26 @@ class WindowsCountersNode(nodes.LazyNode):
         except (KeyError, TypeError, IndexError):
             sleep = 0
 
+        try:
+            factor = int(kwargs['factor'][0])
+        except (KeyError, TypeError, IndexError):
+            factor = 0
+
         query = win32pdh.OpenQuery()
         try:
             counter = win32pdh.AddCounter(query, counter_path)
             try:
+
+                if factor != 0:
+                    # Multiply results by 10^(factor) to get around limitations on threshold types
+                    win32pdh.SetCounterScaleFactor(query, factor)
+
                 win32pdh.CollectQueryData(query)
+
                 if sleep != 0:
                     time.sleep(sleep)
                     win32pdh.CollectQueryData(query)
+
                 _, _, _, _, _, _, _, info, _ = win32pdh.GetCounterInfo(counter, False)
                 _, value = win32pdh.GetFormattedCounterValue(counter, win32pdh.PDH_FMT_DOUBLE)
             finally:

--- a/agent/listener/windowscounters.py
+++ b/agent/listener/windowscounters.py
@@ -67,7 +67,7 @@ class WindowsCountersNode(nodes.LazyNode):
 
                 if factor != 0:
                     # Multiply results by 10^(factor) to get around limitations on threshold types
-                    win32pdh.SetCounterScaleFactor(query, factor)
+                    win32pdh.SetCounterScaleFactor(counter, factor)
 
                 win32pdh.CollectQueryData(query)
 


### PR DESCRIPTION
Partially resolves #508. Users can scale up the result as much as they need to, which allows them to set thresholds in whole numbers of whatever unit they prefer. (so, a user querying a counter that would normally return .02 can now set factor=3 and it'll return 20)