### PR TITLE
Fixed: check_ncpa.py: Incompatability with Python 3.7.4

### DIFF
--- a/client/CHANGES.rst
+++ b/client/CHANGES.rst
@@ -1,9 +1,13 @@
 Changelog
 +++++++++
 
+1.1.7
+-----
+- Fixed incompatability with Python 3.7.4 (Christian Zettel)
+
 1.1.6
 -----
-- Fixed list api tree only possible with activated verbose mode
+- Fixed list api tree only possible with activated verbose mode (Christian Zettel)
 
 1.1.5
 -----


### PR DESCRIPTION
Fixed: Issue:#566
Some newlines added/removed.
Simplified section, where performance data will be build.

Some tests:

Python version 3:
```bash
19:27:25 [nagios@localhost]:~/Dokumente/git-repos/ncpa/client$ env python --version
Python 3.7.4
```

Test with python 3.7.4:
```bash
19:27:33 [nagios@localhost]:~/Dokumente/git-repos/ncpa/client$ ./check_ncpa.py -H 10.0.0.73 -t mytoken -M /api/system/agent_version --performance
OK: Agent_version was ['2.1.9'] | 'status'=0;1;2;;
```

Python version 2:
```bash
19:31:01 [nagios@localhost]:~/Downloads$ env python2.7 --version
Python 2.7.16
```

Test with python 2.7.16:
```bash
19:31:08 [nagios@localhost]:~/Downloads$ python2.7 ./check_ncpa.py -H 10.0.0.73 -t mytoken -M /api/system/agent_version --performance
OK: Agent_version was ['2.1.9'] | 'status'=0;1;2;
```



