### PR TITLE
Fixed: Option: --performance is incompatible with Python 2.6.6

### DIFF
--- a/client/CHANGES.rst
+++ b/client/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.7
 -----
 - Fixed incompatability with Python 3.7.4 (Christian Zettel)
+- Fixed Option: --performance is incompatible with Python 2.2.6 (Christian Zettel)
 
 1.1.6
 -----

--- a/client/CHANGES.rst
+++ b/client/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.1.7
 -----
-- Fixed incompatability with Python 3.7.4 (Christian Zettel)
+- Fixed incompatibility with Python 3.7.4 (Christian Zettel)
 - Fixed Option: --performance is incompatible with Python 2.2.6 (Christian Zettel)
 
 1.1.6

--- a/client/CHANGES.rst
+++ b/client/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.1.7
 -----
 - Fixed incompatibility with Python 3.7.4 (Christian Zettel)
-- Fixed Option: --performance is incompatible with Python 2.2.6 (Christian Zettel)
+- Fixed Option: --performance is incompatible with Python 2.6.6 (Christian Zettel)
 
 1.1.6
 -----

--- a/client/check_ncpa.py
+++ b/client/check_ncpa.py
@@ -289,13 +289,13 @@ def main():
             stdout, returncode = run_check(info_json)
 
             if options.performance and stdout.find("|") == -1:
-                stdout = "{} | 'status'={};1;2;;".format(stdout, returncode)
+                stdout = "{0} | 'status'={1};1;2;;".format(stdout, returncode)
             return stdout, returncode
     except Exception as e:
         if options.debug:
-            return 'The stack trace:' + traceback.format_exc(), 3
+            return 'The stack trace:\n' + traceback.format_exc(), 3
         elif options.verbose:
-            return 'An error occurred:' + str(e), 3
+            return 'An error occurred:\n' + str(e), 3
         else:
             return 'UNKNOWN: Error occurred while running the plugin. Use the verbose flag for more details.', 3
 


### PR DESCRIPTION
Fixed issue: #568 
Newlines added in case options: verbose or debug are set.

Test:

Python version:
```bash
20:09:21 [root@nagios4]:/usr/local/nagios/libexec# env python --version
Python 2.6.6
```

Test with python 2.6.6:
```bash
20:09:26 [root@nagios4]:/usr/local/nagios/libexec# ./check_ncpa.py -H 10.0.0.73 -t mytoken -M /api/system/agent_version --performance 
OK: Agent_version was ['2.1.9'] | 'status'=0;1;2;;
```

Python version:
```bash
20:13:44 [root@localhost]:~/Dokumente/git-repos/ncpa$ env python --version
Python 3.7.4
```

Test with python 3.7.4:
```bash
20:11:57 [root@localhost]:~/Dokumente/git-repos/ncpa$ ./client/check_ncpa.py -H 10.0.0.73 -t mytoken -M /api/system/agent_version --performance
OK: Agent_version was ['2.1.9'] | 'status'=0;1;2;;
```