### PR TITLE
Update build for MacOS

### DIFF
--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -162,12 +162,18 @@ On DEB-based systems::
 Building on Mac OS X
 ====================
 
-Working on this section. It's basically the same as Linux, however you may need to
-install the libraries and python differently. You'll also have to use the following command
-to build the dmg::
+Working on this section. Using the new build system, these four lines should be enough
+to create a working NCPA DMG.
 
-  cd build
-  make build_dmg
+    sudo su -
+    xcode-select --install
+    cd build
+    ./build.sh
+
+Note that there may be some difficulty with installing this on other machines without
+Apple Developer credentials. As of MacOS Catalina, this means going to 
+System Preferences -> Security & Privacy and explicitly allowing the programs each time
+they run.
 
 Building Tips
 =============

--- a/build/osx/setup.sh
+++ b/build/osx/setup.sh
@@ -1,7 +1,54 @@
 #!/bin/bash -e
 
+PYTHONTAR="Python-2.7.14"
 PYTHONBIN="python"
-
+SKIP_PYTHON=0
+CXFREEZEVER="cx_Freeze-4.3.4"
 update_py_packages() {
     $PYTHONBIN -m pip install -r $BUILD_DIR/resources/require.txt --upgrade
 }
+
+install_prereqs() {
+
+    cd $BUILD_DIR/resources
+
+    # Install bundled Python version from source
+    if [ $SKIP_PYTHON -eq 0 ]; then
+        tar xf $PYTHONTAR.tgz
+        cd $PYTHONTAR
+        ./configure LDFLAGS='-Wl,-rpath,\$${ORIGIN} -Wl,-rpath,\$${ORIGIN}/lib' && make && make altinstall
+        cd ..
+        rm -rf $PYTHONTAR
+        PYTHONBIN=$(which python2.7)
+        
+        # Link lib-dynload from lib64 to lib due to arch issues for Python 2.7
+        if [ "$dist" == "os15" ]; then
+            ln -s /usr/local/lib64/python2.7/lib-dynload/ /usr/local/lib/python2.7/lib-dynload
+        fi
+    fi
+
+    # Install the patched version of cx_Freeze
+    tar xf $CXFREEZEVER.tar.gz
+    cd $CXFREEZEVER
+    $PYTHONBIN setup.py install
+    cd ..
+    rm -rf $CXFREEZEVER
+
+    # --------------------------
+    #  INSTALL PIP & PIP MODULES
+    # --------------------------
+
+    # Install pip
+    cd /tmp && wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py && $PYTHONBIN /tmp/get-pip.py
+
+    # Install modules
+    update_py_packages
+
+	# Add users/groups
+	set +e
+	sudo sysadminctl -addUser nagios
+	sudo dseditgroup -o create nagios
+	sudo dseditgroup -o edit -a nagios -t user nagios
+	set -e
+}
+


### PR DESCRIPTION
Setup.sh should match the one used for linux, except for lines 49-51.

I also noticed that build.sh had to be run as root, not sure if that's normal for linux as well.