### PR TITLE
Plugins directory can now contain subdirectories

### DIFF
--- a/agent/listener/pluginnodes.py
+++ b/agent/listener/pluginnodes.py
@@ -188,13 +188,13 @@ class PluginAgentNode(nodes.ParentNode):
         self.children = {}
 
         try:
-            plugins = os.listdir(plugin_path)
-            for plugin in plugins:
-                if plugin == '.keep':
-                    continue
-                plugin_abs_path = os.path.join(plugin_path, plugin)
-                if os.path.isfile(plugin_abs_path):
-                    self.children[plugin] = PluginNode(plugin, plugin_abs_path)
+            for root,dirs,files in os.walk(plugin_path,followlinks=True):
+                for plugin in files:
+                    if plugin == '.keep':
+                        continue
+                    plugin_abs_path = os.path.join(root, plugin)
+                    if os.path.isfile(plugin_abs_path):
+                        self.children[plugin] = PluginNode(plugin, plugin_abs_path)
         except OSError as exc:
             logging.warning('Unable to access directory %s', plugin_path)
             logging.warning('Unable to assemble plugins. Does the directory exist? - %r', exc)


### PR DESCRIPTION
Moving from nrpe, we have several directories of plugins that we define and use, some internally developed in one repo, some from the OS packages, some from external sources. We keep them seperate so they can be updated independently, normally we'd symlink each directory into somewhere like `/usr/lib/nagios/plugins` however ncpa forced one flat directory structure which makes this mechanism very difficult for us to use.

Implements: https://github.com/NagiosEnterprises/ncpa/issues/577 