### PR TITLE
 Implemented issue #606 (Would like to see TTY and PID in list of users)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 - Added version option to ncpa_listener and ncpa_passive (Christian Zettel)
 - Added support of hostnames in allowed_hosts (#653) (Christian Zettel)
 - Added secure cookie attribute (#659)
+- Added new ednpoints in the user node: endpoints pid, started, host, terminal (#606) (Christian Zettel)
 - Fixed issue with allowed_hosts config directive doesnt work (#638, #660) (Christian Zettel)
 - Fixed ncpa_listener fails to start when IPv6 is disabled. (#648) (Christian Zettel)
 - Fixed if an exception was thrown in one api endpoint it breaks the wohle api (#670) (Christian Zettel)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
 - Added version option to ncpa_listener and ncpa_passive (Christian Zettel)
 - Added support of hostnames in allowed_hosts (#653) (Christian Zettel)
 - Added secure cookie attribute (#659)
-- Added new ednpoints in the user node: endpoints pid, started, host, terminal (#606) (Christian Zettel)
+- Added new ednpoints in the user node: pid, started, host, terminal (#606) (Christian Zettel)
 - Fixed issue with allowed_hosts config directive doesnt work (#638, #660) (Christian Zettel)
 - Fixed ncpa_listener fails to start when IPv6 is disabled. (#648) (Christian Zettel)
 - Fixed if an exception was thrown in one api endpoint it breaks the wohle api (#670) (Christian Zettel)

--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -237,11 +237,6 @@ def get_user_start_time(start_time):
     return (int(current_time) - int(start_time))
 
 
-def get_user_start_time(start_time):
-    current_time = time.time()
-    return (int(current_time) - int(start_time))
-
-
 def make_session_nodes(user, users):
     sessions = []
     counter = 0

--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -244,7 +244,6 @@ def get_user_start_time(start_time):
 
 def make_session_nodes(user, users):
     sessions = []
-    childs = []
     counter = 0
 
     for x in users:
@@ -255,11 +254,7 @@ def make_session_nodes(user, users):
             host = RunnableNode('host', method=lambda: (x.host, 'host'))
             started = RunnableNode('started', method=lambda: (start_time, 's'))
             pid = RunnableNode('pid', method=lambda: (x.pid, 'pid'))
-            childs.append(terminal)
-            childs.append(host)
-            childs.append(started)
-            childs.append(pid)
-            sessions.append(ParentNode("session_#{0}".format(counter), children=childs))
+            sessions.append(ParentNode("session_#{0}".format(counter), children=[terminal, started, host, pid]))
 
     return ParentNode(user, children=sessions)
 

--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -217,9 +217,25 @@ def get_plugins_node():
     return PluginAgentNode('plugins')
 
 
+def get_user_start_time(start_time):
+    current_time = time.time()
+    return (int(current_time) - int(start_time))
+
+
+def make_user_nodes(user):
+    start_time = get_user_start_time(user.started)
+    name = RunnableNode('name', method=lambda: (user.name, 'name'))
+    terminal = RunnableNode('terminal', method=lambda: (user.terminal, 'terminal'))
+    host = RunnableNode('host', method=lambda: (user.host, 'host'))
+    started = RunnableNode('started', method=lambda: (start_time, 's'))
+    pid = RunnableNode('pid', method=lambda: (user.pid, 'pid'))
+    return ParentNode(user.pid, children=[name, terminal, host, started, pid])
+
+
 def get_user_node():
     user_count = RunnableNode('count', method=lambda: (len([x.name for x in ps.users()]), 'users'))
-    user_list = RunnableNode('list', method=lambda: ([x.name for x in ps.users()], 'users'))
+    users = [make_user_nodes(x) for x in ps.users()]
+    user_list = ParentNode('user_list', children=users)
     return ParentNode('user', children=[user_count, user_list])
 
 

--- a/agent/listener/static/help/index.html
+++ b/agent/listener/static/help/index.html
@@ -101,6 +101,7 @@ sudo launchctl start com.nagios.ncpa.passive</pre>
                     <p>
                         <ol>
                             <li><b>Allowed hosts</b> - The configuration option <code>allowed_hosts</code> now supports hostnames and IPv4-mapped IPv6 addresses.</li>
+                            <li><b>User</b> - The <code>user</code> node now contains new endpoints: terminal, host, pid, started.</li>
                             <li><b>New configuration option</b> - New configuration option available:
                                 <ol>
                                     <li><code>follow_symlinks</code> - Follow symlinks located in the plugin path</li>


### PR DESCRIPTION
Implemented #606 Would like to see TTY and PID in list of users.
Also added: hostname and start time of the user session.
Not sure if the implemented output structure is ok:
```
{
    "user": {
        "count": [
            2,
            "users"
        ],
        "user_list": {
            "1623": {
                "terminal": [
                    "pts/0",
                    "terminal"
                ],
                "started": [
                    153,
                    "s"
                ],
                "host": [
                    "10.0.0.80",
                    "host"
                ],
                "pid": [
                    1623,
                    "pid"
                ],
                "name": [
                    "zet",
                    "name"
                ]
            },
            "1659": {
                "terminal": [
                    "pts/1",
                    "terminal"
                ],
                "started": [
                    25,
                    "s"
                ],
                "host": [
                    "tux01.daham.home",
                    "host"
                ],
                "pid": [
                    1659,
                    "pid"
                ],
                "name": [
                    "root",
                    "name"
                ]
            }
        }
    }
}
```