### PR TITLE
Fix Python 3 error

### DIFF
--- a/client/check_ncpa.py
+++ b/client/check_ncpa.py
@@ -259,7 +259,7 @@ def get_json(options):
     ret = ret.read()
 
     if options.verbose:
-        print('File returned contained:\n' + ret)
+        print('File returned contained:\n' + ret.decode('utf-8'))
 
     arr = json.loads(ret)
 


### PR DESCRIPTION
Python 3 generates an error if you try to concatenate a Unicode string with a byte string.

Reading from a file produces a byte string.

Solution: Turn it into a Unicode string.

Closes #710