### PR TITLE
Fixed issues described in #714

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Changelog
 - Fixed ncpa_listener fails to start when IPv6 is disabled. (#648) (Christian Zettel)
 - Fixed if an exception was thrown in one api endpoint it breaks the wohle api (#670) (Christian Zettel)
 - Fixed missing unit (%) for some process checks (#681) (Christian Zettel)
-- Fixed childs started from a plugin will not be killed in case plugin_output was reached (#714) (Christian Zettel)
+- Fixed childs started from a plugin will not be killed in case plugin_timeout was reached (#714) (Christian Zettel)
 - Fixed error message in case plugin runs into timeout out was not shown (#714) (Christian Zettel)
 
 2.2.2 - 06/19/2020

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ Changelog
 - Fixed ncpa_listener fails to start when IPv6 is disabled. (#648) (Christian Zettel)
 - Fixed if an exception was thrown in one api endpoint it breaks the wohle api (#670) (Christian Zettel)
 - Fixed missing unit (%) for some process checks (#681) (Christian Zettel)
-- Fixed childs started from a plugin will not be killed in case plugin_output was rechaed (#714) (Christian Zettel)
-- Fixed error message in case plugin timed out was not shown (#714) (Christian Zettel)
+- Fixed childs started from a plugin will not be killed in case plugin_output was reached (#714) (Christian Zettel)
+- Fixed error message in case plugin runs into timeout out was not shown (#714) (Christian Zettel)
 
 2.2.2 - 06/19/2020
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Changelog
 - Fixed ncpa_listener fails to start when IPv6 is disabled. (#648) (Christian Zettel)
 - Fixed if an exception was thrown in one api endpoint it breaks the wohle api (#670) (Christian Zettel)
 - Fixed missing unit (%) for some process checks (#681) (Christian Zettel)
+- Fixed childs started from a plugin will not be killed in case plugin_output was rechaed (#714) (Christian Zettel)
+- Fixed error message in case plugin timed out was not shown (#714) (Christian Zettel)
 
 2.2.2 - 06/19/2020
 ==================

--- a/agent/listener/pluginnodes.py
+++ b/agent/listener/pluginnodes.py
@@ -67,7 +67,7 @@ class PluginNode(nodes.RunnableNode):
         except ConfigParser.NoOptionError:
             return '$plugin_name $plugin_args'
 
-    def kill_proc(self, p):
+    def kill_proc(self, p, t):
         self.killed = True
         if environment.SYSTEM == 'Windows':
             p.kill()

--- a/agent/listener/pluginnodes.py
+++ b/agent/listener/pluginnodes.py
@@ -67,7 +67,7 @@ class PluginNode(nodes.RunnableNode):
         except ConfigParser.NoOptionError:
             return '$plugin_name $plugin_args'
 
-    def kill_proc(self, p, t):
+    def kill_proc(self, p):
         self.killed = True
         if environment.SYSTEM == 'Windows':
             p.kill()

--- a/agent/listener/pluginnodes.py
+++ b/agent/listener/pluginnodes.py
@@ -9,10 +9,10 @@ import subprocess
 import shlex
 import re
 import copy
-import Queue
 import environment
 import database
 import server
+import signal
 from threading import Timer
 
 # Windows does not have the pwd and grp module and does not need it since only Unix
@@ -33,6 +33,7 @@ class PluginNode(nodes.RunnableNode):
         self.name = plugin
         self.plugin_abs_path = plugin_abs_path
         self.arguments = []
+        self.killed = False
 
     def accessor(self, path, config, full_path, args):
 
@@ -66,9 +67,12 @@ class PluginNode(nodes.RunnableNode):
         except ConfigParser.NoOptionError:
             return '$plugin_name $plugin_args'
 
-    def kill_proc(self, p, t, q):
-        p.kill()
-        q.put("Error: Plugin command timed out. (%d sec)" % t)
+    def kill_proc(self, p, t):
+        self.killed = True
+        if environment.SYSTEM == 'Windows':
+            p.kill()
+        else:
+            os.killpg(p.pid, signal.SIGKILL)
 
     def execute_plugin(self, config, *args, **kwargs):
         """Runs custom scripts that MUST be located in the scripts subdirectory
@@ -104,9 +108,13 @@ class PluginNode(nodes.RunnableNode):
 
         # Run the command in a new subprocess
         run_time_start = time.time()
-        running_check = subprocess.Popen(cmd, bufsize=-1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        queue = Queue.Queue(maxsize=2)
-        timer = Timer(timeout, self.kill_proc, [running_check, timeout, queue])
+
+        if environment.SYSTEM == 'Windows':
+            running_check = subprocess.Popen(cmd, bufsize=-1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        else:
+            running_check = subprocess.Popen(cmd, bufsize=-1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, preexec_fn=os.setsid)
+
+        timer = Timer(timeout, self.kill_proc, [running_check, timeout])
 
         try:
             timer.start()
@@ -117,10 +125,11 @@ class PluginNode(nodes.RunnableNode):
         run_time_end = time.time()
         returncode = running_check.returncode
 
-        # Pull from the queue if we have a error and the stdout is empty
-        if returncode == 1 and not stdout:
-            if queue.qsize() > 0:
-                stdout = queue.get()
+        # In case the plugin call timed out, set stdout and returncode to an error
+        if self.killed:
+            stdout = 'Error: Plugin command ({0}) timed out. ({1} sec)'.format(' '.join(cmd), timeout)
+            returncode = -1
+            logging.error(stdout)
 
         cleaned_stdout = unicode(''.join(stdout.decode("utf-8", "ignore")).replace('\r\n', '\n').replace('\r', '\n').strip())
 

--- a/agent/ncpa_listener.py
+++ b/agent/ncpa_listener.py
@@ -111,7 +111,7 @@ class Listener(ncpadaemon.Daemon):
                 http_server.serve_forever()
             except SocketError as e:
                 if address == '::':
-                    logging.info("Failed to start in dual stack mode: %s", e)
+                    logging.error("Failed to start in dual stack mode: %s", e)
                     logging.info("Falling back to IPv4 only")
                 else:
                     logging.exception(e)

--- a/agent/ncpa_windows.py
+++ b/agent/ncpa_windows.py
@@ -203,7 +203,7 @@ class Listener(Base):
                 http_server.serve_forever()
             except SocketError as e:
                 if address == '::':
-                    logging.info("Failed to start in dual stack mode: %s", e)
+                    logging.error("Failed to start in dual stack mode: %s", e)
                     logging.info("Falling back to IPv4 only")
                 else:
                     logging.exception(e)

--- a/build/linux/setup.sh
+++ b/build/linux/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Globals
-PYTHONTAR="Python-2.7.16"
+PYTHONTAR="Python-2.7.18"
 PYTHONVER="python2.7"
 CXFREEZEVER="cx_Freeze-4.3.4"
 SKIP_PYTHON=0
@@ -11,7 +11,12 @@ SKIP_PYTHON=0
 
 update_py_packages() {
     PYTHONBIN=$(which python2.7)
-    LDFLAGS='-Wl,-rpath,\${ORIGIN} -Wl,-rpath,\${ORIGIN}/lib' $PYTHONBIN -m pip install -r $BUILD_DIR/resources/require.txt --upgrade --no-binary :all:
+    resources="require.txt"
+    if [ "$dist" == "el6" ] || [ "$dist" == "el7" ] || [ "$dist" == "debian8" ]; then
+        resources="require.dep.txt"
+    fi
+
+    LDFLAGS='-Wl,-rpath,\${ORIGIN} -Wl,-rpath,\${ORIGIN}/lib' $PYTHONBIN -m pip install -r $BUILD_DIR/resources/$resources --upgrade --no-binary :all:
 }
 
 install_prereqs() {

--- a/build/osx/setup.sh
+++ b/build/osx/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-PYTHONTAR="Python-2.7.14"
+PYTHONTAR="Python-2.7.18"
 PYTHONBIN="python"
 SKIP_PYTHON=0
 CXFREEZEVER="cx_Freeze-4.3.4"

--- a/build/resources/require.dep.txt
+++ b/build/resources/require.dep.txt
@@ -1,0 +1,14 @@
+psutil
+requests
+Jinja2
+flask==0.10.1
+werkzeug==0.16.1
+docutils
+pyOpenSSL==19.1
+cryptography==2.8
+gevent==1.2.2
+gevent-websocket
+cffi
+appdirs
+packaging
+kafka

--- a/build/solaris/setup.sh
+++ b/build/solaris/setup.sh
@@ -4,7 +4,7 @@
 PATH=$PATH:/opt/csw/bin:/usr/ccs/bin
 
 # Globals
-PYTHONTAR="Python-2.7.16"
+PYTHONTAR="Python-2.7.18"
 PYTHONVER="python2.7"
 PYTHONBIN="/usr/local/bin/python2.7"
 CXFREEZEVER="cx_Freeze-4.3.4"


### PR DESCRIPTION
Fixed issues described [here](https://github.com/NagiosEnterprises/ncpa/issues/714#issuecomment-733932219):

1. When the plugin will be killed after reaching the plugin_timeout the kill signal will not be propagated to childs started from the plugin. The leftover childs are keeping the curl connection open
2. The error message in case of a timeout will not be displayed


- Python updated to latest 2.x.x version: [2.7.18](https://www.python.org/downloads/release/python-2718/)
- Fixed the build process for RHEL7 (like it was already fixed in the master branch for RHEL6)
- Changed the loglevel of some logmessages from INFO to ERROR.