### PR TITLE
Fixed: check_ncpa option to return "Unknown" status when "socket time…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 - ??/??/2021
 ==================
 - Added new disk metrics max_file_length and max_path_length (#760) (ccztux)
+- Changed the default plugin_timeout value from 60s to 59s (#761) (ccztux)
 
 2.3.1 - 02/11/2021
 ==================

--- a/agent/etc/ncpa.cfg
+++ b/agent/etc/ncpa.cfg
@@ -316,9 +316,9 @@ follow_symlinks = 0
 # Plugin execution timeout in seconds. Different than the check_ncpa.py timeout, which is
 # normally for network connection issues. Will return a CRITICAL value and error when the plugin
 # reaches the defined max execution timeout and kills the process.
-# Default: 60
+# Default: 59
 #
-# plugin_timeout = 60
+# plugin_timeout = 59
 
 #
 # Comma separated list of plugins to run through sudo. Note: You will need to update your sudoers

--- a/agent/etc/ncpa.cfg.sample
+++ b/agent/etc/ncpa.cfg.sample
@@ -288,9 +288,9 @@ follow_symlinks = 0
 # Plugin execution timeout in seconds. Different than the check_ncpa.py timeout, which is
 # normally for network connection issues. Will return a CRITICAL value and error when the plugin
 # reaches the defined max execution timeout and kills the process.
-# Default: 60
+# Default: 59
 #
-# plugin_timeout = 60
+# plugin_timeout = 59
 
 #
 # Comma separated list of plugins to run through sudo. Note: You will need to update your sudoers

--- a/agent/listener/pluginnodes.py
+++ b/agent/listener/pluginnodes.py
@@ -86,7 +86,7 @@ class PluginNode(nodes.RunnableNode):
         try:
             timeout = int(config.get('plugin directives', 'plugin_timeout'))
         except Exception as e:
-            timeout = 60
+            timeout = 59
 
         # Get the check logging value
         try:

--- a/agent/listener/static/help/configuration.html
+++ b/agent/listener/static/help/configuration.html
@@ -484,7 +484,7 @@
                             <tr>
                                 <td></td>
                                 <th>plugin_timeout</th>
-                                <td>60</td>
+                                <td>59</td>
                                 <td>The plugin execution timeout on the NCPA side. For both active and passive checks. There is also a timeout specified in <code>check_ncpa.py</code>.</td>
                             </tr>
                         </tbody>

--- a/agent/listener/static/help/index.html
+++ b/agent/listener/static/help/index.html
@@ -106,6 +106,7 @@ sudo launchctl start com.nagios.ncpa.passive</pre>
                                     <li><code>logical/max_path_length</code> - The maximum length a path name (directory name + base file name) can have</li>
                                 </ol>
                             </li>
+                            <li><b>Plugin timeout</b> - The default value of the configuration option <code>plugin_timeout</code> was changed from <b>60s</b> to <b>59s</b>.</li>
                         </ol>
                     </p>
 

--- a/client/CHANGES.rst
+++ b/client/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.2.5
 -----
-- Changed the default timeout value from 60s to 59s (#761) (ccztux)
+- Changed the default timeout value from 60s to 58s (#761) (ccztux)
 
 1.2.4
 -----

--- a/client/check_ncpa.py
+++ b/client/check_ncpa.py
@@ -99,7 +99,7 @@ def parse_args():
                            "as you would call from the command line. Example: -a '-w 10 -c 20 -f /usr/local'")
     parser.add_option("-t", "--token", default='',
                       help="The token for connecting.")
-    parser.add_option("-T", "--timeout", default=59, type="int",
+    parser.add_option("-T", "--timeout", default=58, type="int",
                       help="Enforced timeout, will terminate plugins after "
                            "this amount of seconds. [Default: %default]")
     parser.add_option("-d", "--delta", action='store_true',


### PR DESCRIPTION
…out" is encountered (#761)

According to [the knowledge base entry](https://support.nagios.com/kb/article/ncpa-service-check-timed-out-after-n-seconds-872.html) i have changed the timeout values again.