### PR TITLE
fixed URL for fetching pip

### DIFF
--- a/build/linux/setup.sh
+++ b/build/linux/setup.sh
@@ -136,7 +136,8 @@ install_prereqs() {
 
 
     # Install pip
-    cd /tmp && wget --no-check-certificate https://raw.githubusercontent.com/pypa/get-pip/master/2.7/get-pip.py && $PYTHONBIN /tmp/get-pip.py
+    # Updated URL for fetching pip for Python2.7, old URL was broken
+    cd /tmp && wget --no-check-certificate https://bootstrap.pypa.io/pip/2.7/get-pip.py && $PYTHONBIN /tmp/get-pip.py
 
     # Install modules
     update_py_packages


### PR DESCRIPTION
the URL for fetching get-pip.py is broken, updated it with a functional one