### PR TITLE
Exclude filter and additional options for matching services by start type

### DIFF
--- a/agent/listener/templates/gui/api.html
+++ b/agent/listener/templates/gui/api.html
@@ -1059,7 +1059,7 @@ function generate_passive_check() {
                     <div class="checkbox">
                         <label><input type="checkbox" class="exclude" name="exclude" value="1"> Exclude above</label>
                     </div>
-                    <div class="input-group match">
+                    <div class="input-group start-type">
                         <div class="input-group-addon">Start type</div>
                         <select class="form-control start-type">
                             <option></option>

--- a/agent/listener/templates/gui/api.html
+++ b/agent/listener/templates/gui/api.html
@@ -571,6 +571,16 @@ function generate_url(skip_settings, use_for_pcheck) {
                 extra += '&service=' + val;
             }
         });
+
+        var start_type = $('select.start-type').val();
+        if (start_type != '') {
+            extra += '&start_type=' + start_type;
+        }
+
+        var exclude = $('input.exclude').is(':checked');
+        if (exclude) {
+            extra += '&exclude=';
+        }
     }
 
     // Apply filters for processes
@@ -1045,6 +1055,17 @@ function generate_passive_check() {
                         <button type="button" class="btn btn-xs btn-default add-service">
                             <i class="fa fa-plus"></i> Add Filter
                         </button>
+                    </div>
+                    <div class="checkbox">
+                        <label><input type="checkbox" class="exclude" name="exclude" value="1"> Exclude above</label>
+                    </div>
+                    <div class="input-group match">
+                        <div class="input-group-addon">Start type</div>
+                        <select class="form-control start-type">
+                            <option></option>
+                            <option value="automatic">automatic</option>
+                            <option value="manual">manual</option>
+                        </select>
                     </div>
                 </div>
                 <div class="settings proc-filters">


### PR DESCRIPTION
Referring to issue #744 , for the Exclude filter the original Service Filter input(s) are used along with the Exclude Above checkbox; for the Start Type both automatic and manual (or all by choosing the blank option) are available in order to further narrow down the service selection.

![image](https://user-images.githubusercontent.com/25744318/151663929-bfd4b6b3-5d7f-455a-aa2e-881095d52847.png)

Without filtering out (with Exclude) the output would look like:

![image](https://user-images.githubusercontent.com/25744318/151664170-016e8f6f-65e1-47fa-8668-b4061043efea.png)