### PR TITLE
Fixed: Plugin arguments doesnt work with check_http_json.py (#937)

### DIFF
--- a/client/CHANGES.rst
+++ b/client/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.5
 -----
 - Changed the default timeout value from 60s to 58s (#761) (ccztux)
+- Added argument -r to handle complex plugin arguments (#937) (ccztux)
 
 1.2.4
 -----

--- a/client/check_ncpa.py
+++ b/client/check_ncpa.py
@@ -132,9 +132,10 @@ def parse_args():
         print(version)
         sys.exit(0)
 
-    if options.arguments or options.raw_plugin_args and options.metric and not 'plugin' in options.metric:
-        parser.print_help()
-        parser.error('You cannot specify arguments without running a custom plugin.')
+    if options.arguments or options.raw_plugin_args:
+        if options.metric and not 'plugin' in options.metric:
+            parser.print_help()
+            parser.error('You cannot specify arguments without running a custom plugin.')
 
     if options.arguments and options.raw_plugin_args:
         parser.print_help()


### PR DESCRIPTION
The fix adds the following new argument to `check_ncpa.py`:

```
  -r RAW_PLUGIN_ARGS, --raw-plugin-args=RAW_PLUGIN_ARGS
                        Raw plugin arguments for the plugin to be run. This is
                        an alternative to -a and should be used if the
                        arguments are more complex, like URL parameters.
                        Example: -r '-H inside01 -P 443 -p interface-
                        rest/incident/count?incidentType=failedTask -s -w
                        count,@1: -c count,@1: -e count'
```

The new argument handles complex plugin arguments well. Not sure if the new agument can replace -a, so i have added a new one.