### PR TITLE
Mac Build - fixing malformed plist & Sudo issues

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -194,14 +194,15 @@ fi
     cd $AGENT_DIR
 
     echo -e "\nFreezing app (may take a minute)..."
-    sudo $PYTHONBIN setup.py build_exe > $BUILD_DIR/build.log
+    sudo $PYTHONBIN setup.py build_exe | sudo tee $BUILD_DIR/build.log
+
 
     echo -e "\nSet up packaging dirs..."
     # Move the ncpa binary data
     cd $BUILD_DIR
     sudo rm -rf $BUILD_DIR/ncpa
     sudo cp -rf $AGENT_DIR/build/exe.* $BUILD_DIR/ncpa
-    sudo sh -c "echo $GIT_LONG > $BUILD_DIR/ncpa/$GIT_HASH_FILE"
+    echo $GIT_LONG | sudo tee $BUILD_DIR/ncpa/$GIT_HASH_FILE
 
     # REMOVE LIBFFI COPY - PLEASE CHANGE THIS LATER
     # It should be in .libs_cffi_backend for proper linking and
@@ -225,11 +226,11 @@ fi
     sudo cp -rf ncpa ncpa-$NCPA_VER
     if [ "$UNAME" == "AIX" ]; then
         echo -e "***** Build tarball"
-        sudo tar cvf ncpa-$NCPA_VER.tar ncpa-$NCPA_VER >> $BUILD_DIR/build.log
-        sudo gzip -f ncpa-$NCPA_VER.tar >> $BUILD_DIR/build.log
+        sudo tar cvf ncpa-$NCPA_VER.tar ncpa-$NCPA_VER | sudo tee -a $BUILD_DIR/build.log
+        sudo gzip -f ncpa-$NCPA_VER.tar | sudo tee -a $BUILD_DIR/build.log
     elif [ "$UNAME" == "Linux" ]; then
         echo -e "***** Build tarball"
-        sudo tar -czvf ncpa-$NCPA_VER.tar.gz ncpa-$NCPA_VER >> $BUILD_DIR/build.log
+        sudo tar -czvf ncpa-$NCPA_VER.tar.gz ncpa-$NCPA_VER | sudo tee -a $BUILD_DIR/build.log
     fi
 )
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -133,7 +133,7 @@ if [ $BUILD_TRAVIS -eq 0 ] && [ $PACKAGE_ONLY -eq 0 ] && [ $BUILD_ONLY -eq 0 ]; 
         read -r -p "Automatically install system pre-reqs? [Y/n] " resp
         if [[ $resp =~ ^(yes|y|Y| ) ]] || [[ -z $resp ]]; then
             install_prereqs
-            touch $BUILD_DIR/prereqs.installed
+            sudo touch $BUILD_DIR/prereqs.installed
         fi
     fi
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -164,9 +164,9 @@ clean_build_dir
 # Build the python with cx_Freeze
 cd $BUILD_DIR
 find $AGENT_DIR -name *.pyc -exec rm '{}' \;
-mkdir -p $AGENT_DIR/plugins
-mkdir -p $AGENT_DIR/build
-mkdir -p $AGENT_DIR/var/log
+sudo mkdir -p $AGENT_DIR/plugins
+sudo mkdir -p $AGENT_DIR/build
+sudo mkdir -p $AGENT_DIR/var/log
 # cat /dev/null > $AGENT_DIR/var/log/ncpa_passive.log
 # cat /dev/null > $AGENT_DIR/var/log/ncpa_listener.log
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -201,14 +201,14 @@ fi
     cd $BUILD_DIR
     sudo rm -rf $BUILD_DIR/ncpa
     cp -rf $AGENT_DIR/build/exe.* $BUILD_DIR/ncpa
-    echo $GIT_LONG >  $BUILD_DIR/ncpa/$GIT_HASH_FILE
+    sudo echo $GIT_LONG >  $BUILD_DIR/ncpa/$GIT_HASH_FILE
 
     # REMOVE LIBFFI COPY - PLEASE CHANGE THIS LATER
     # It should be in .libs_cffi_backend for proper linking and
     # possibly in the future we will fix this but we have to include
     # the exact version ... this will delete the duplicate which should
     # have a special name like libffi-6322464e.so.6.0.4
-    rm -f $BUILD_DIR/ncpa/libffi-*.so.*
+    sudo rm -f $BUILD_DIR/ncpa/libffi-*.so.*
 
     # Set permissions
     sudo chmod -R g+r $BUILD_DIR/ncpa
@@ -222,14 +222,14 @@ fi
 
     # Build tarball
     echo -e "\nBuilding tarball..."
-    cp -rf ncpa ncpa-$NCPA_VER
+    sudo cp -rf ncpa ncpa-$NCPA_VER
     if [ "$UNAME" == "AIX" ]; then
         echo -e "***** Build tarball"
-        tar cvf ncpa-$NCPA_VER.tar ncpa-$NCPA_VER >> $BUILD_DIR/build.log
-        gzip -f ncpa-$NCPA_VER.tar >> $BUILD_DIR/build.log
+        sudo tar cvf ncpa-$NCPA_VER.tar ncpa-$NCPA_VER >> $BUILD_DIR/build.log
+        sudo gzip -f ncpa-$NCPA_VER.tar >> $BUILD_DIR/build.log
     elif [ "$UNAME" == "Linux" ]; then
         echo -e "***** Build tarball"
-        tar -czvf ncpa-$NCPA_VER.tar.gz ncpa-$NCPA_VER >> $BUILD_DIR/build.log
+        sudo tar -czvf ncpa-$NCPA_VER.tar.gz ncpa-$NCPA_VER >> $BUILD_DIR/build.log
     fi
 )
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -113,6 +113,7 @@ done
 # Load required things for different systems
 echo -e "\nRunning build for: $UNAME"
 if [ "$UNAME" == "Linux" ]; then
+    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin:$PATH
     . $BUILD_DIR/linux/setup.sh
 elif [ "$UNAME" == "SunOS" ] || [ "$UNAME" == "Solaris" ]; then
     . $BUILD_DIR/solaris/setup.sh

--- a/build/build.sh
+++ b/build/build.sh
@@ -194,7 +194,7 @@ fi
     cd $AGENT_DIR
 
     echo -e "\nFreezing app (may take a minute)..."
-    $PYTHONBIN setup.py build_exe > $BUILD_DIR/build.log
+    sudo $PYTHONBIN setup.py build_exe > $BUILD_DIR/build.log
 
     echo -e "\nSet up packaging dirs..."
     # Move the ncpa binary data

--- a/build/build.sh
+++ b/build/build.sh
@@ -200,7 +200,7 @@ fi
     # Move the ncpa binary data
     cd $BUILD_DIR
     sudo rm -rf $BUILD_DIR/ncpa
-    cp -rf $AGENT_DIR/build/exe.* $BUILD_DIR/ncpa
+    sudo cp -rf $AGENT_DIR/build/exe.* $BUILD_DIR/ncpa
     sudo echo $GIT_LONG >  $BUILD_DIR/ncpa/$GIT_HASH_FILE
 
     # REMOVE LIBFFI COPY - PLEASE CHANGE THIS LATER

--- a/build/build.sh
+++ b/build/build.sh
@@ -195,7 +195,7 @@ fi
     cd $AGENT_DIR
 
     echo -e "\nFreezing app (may take a minute)..."
-    sudo $PYTHONBIN setup.py build_exe | sudo tee $BUILD_DIR/build.log
+    $PYTHONBIN setup.py build_exe | sudo tee $BUILD_DIR/build.log
 
 
     echo -e "\nSet up packaging dirs..."

--- a/build/build.sh
+++ b/build/build.sh
@@ -201,7 +201,7 @@ fi
     cd $BUILD_DIR
     sudo rm -rf $BUILD_DIR/ncpa
     sudo cp -rf $AGENT_DIR/build/exe.* $BUILD_DIR/ncpa
-    sudo echo $GIT_LONG >  $BUILD_DIR/ncpa/$GIT_HASH_FILE
+    sudo sh -c "echo $GIT_LONG > $BUILD_DIR/ncpa/$GIT_HASH_FILE"
 
     # REMOVE LIBFFI COPY - PLEASE CHANGE THIS LATER
     # It should be in .libs_cffi_backend for proper linking and

--- a/build/macos/installers.sh
+++ b/build/macos/installers.sh
@@ -40,7 +40,7 @@ install_devtools() {
     fi
 
     # Add brew env vars to your environment
-    (echo; echo 'eval "$($BREWBIN shellenv)"') >> ~/.bash_profile
+    echo -e "\n$(eval "$($BREWBIN shellenv)")" | sudo tee -a ~/.bash_profile > /dev/null
     eval "$($BREWBIN shellenv)"
 
     echo -e "    - Installing misc brew packages: pkg-config xz gdbm..."

--- a/build/macos/installers.sh
+++ b/build/macos/installers.sh
@@ -117,8 +117,8 @@ update_py_packages() {
     # For MacOS 11+ libraries need special treatment
     if [[ "$os_major_version" != "10" ]]; then
         if [ ! -d "$pylibpath/lib-dynload_orig" ]; then
-            mkdir $pylibpath/lib-dynload_orig
-            cp $pylibpath/lib-dynload/* $pylibpath/lib-dynload_orig/
+            sudo mkdir $pylibpath/lib-dynload_orig
+            sudo cp $pylibpath/lib-dynload/* $pylibpath/lib-dynload_orig/
         fi
         # Define paths for dependency link fixer
         setPaths
@@ -128,11 +128,11 @@ update_py_packages() {
     fi
 
     if [ ! -d "$cxlibpath/lib-dynload_orig" ]; then
-        mkdir $cxlibpath/lib-dynload_orig
-        cp $cxlibpath/lib-dynload/* $cxlibpath/lib-dynload_orig/
+        sudo mkdir $cxlibpath/lib-dynload_orig
+        sudo cp $cxlibpath/lib-dynload/* $cxlibpath/lib-dynload_orig/
     fi
 
 
     # Link python's lib-dynload to cx_freeze lib-dynload to make sure we are using desired OpenSSL, etc.
-    cp $pylibpath/lib-dynload/* $cxlibpath/lib-dynload/
+    sudo cp $pylibpath/lib-dynload/* $cxlibpath/lib-dynload/
 }

--- a/build/macos/linkdynlibs.sh
+++ b/build/macos/linkdynlibs.sh
@@ -114,7 +114,7 @@ fixLib() {
         echo "    Changing: $badpath/$dylibname"
         echo "    To:       $gdpath/$dylibname"
 
-        install_name_tool -change "$badpath/$dylibname" "$gdpath/$dylibname" "$dynlibpath/$soname"
+        sudo install_name_tool -change "$badpath/$dylibname" "$gdpath/$dylibname" "$dynlibpath/$soname"
     fi
 }
 

--- a/build/macos/linkdynlibs.sh
+++ b/build/macos/linkdynlibs.sh
@@ -22,7 +22,7 @@ setPaths() {
         dynlibpath=$1
     else
         if [[ -z $PYTHONVER ]]; then
-            PYTHONVER="3.11.4"
+            PYTHONVER="3.11.3"
         fi
         python_at_seg=python@$(echo $PYTHONVER | sed 's|\.[0-9]\{1,2\}$||g')
 

--- a/build/macos/package.sh
+++ b/build/macos/package.sh
@@ -52,11 +52,11 @@ ARCH=$(uname -m)
     echo -e "\nDone"
 
     echo -e "\nCopy other resources..."
-    mkdir NCPA-INSTALL-$NCPA_VER
-    mv ncpa-$NCPA_VER NCPA-INSTALL-$NCPA_VER/ncpa
-    cp NCPA-INSTALL-$NCPA_VER/ncpa/build_resources/macosuninstall.sh NCPA-INSTALL-$NCPA_VER/ncpa/uninstall.sh
-    cp NCPA-INSTALL-$NCPA_VER/ncpa/build_resources/macosreadme.txt NCPA-INSTALL-$NCPA_VER/readme.txt
-    mv NCPA-INSTALL-$NCPA_VER/ncpa/build_resources/macosinstall.sh NCPA-INSTALL-$NCPA_VER/install.sh
+    sudo mkdir NCPA-INSTALL-$NCPA_VER
+    sudo mv ncpa-$NCPA_VER NCPA-INSTALL-$NCPA_VER/ncpa
+    sudo cp NCPA-INSTALL-$NCPA_VER/ncpa/build_resources/macosuninstall.sh NCPA-INSTALL-$NCPA_VER/ncpa/uninstall.sh
+    sudo cp NCPA-INSTALL-$NCPA_VER/ncpa/build_resources/macosreadme.txt NCPA-INSTALL-$NCPA_VER/readme.txt
+    sudo mv NCPA-INSTALL-$NCPA_VER/ncpa/build_resources/macosinstall.sh NCPA-INSTALL-$NCPA_VER/install.sh
 
     # Create MacOS disk image file
     echo -e "\nCreate .dmg file ..."

--- a/build/macos/package.sh
+++ b/build/macos/package.sh
@@ -43,7 +43,7 @@ ARCH=$(uname -m)
         parentlib=$(echo ${fixlib} | cut -f3 -d~)
         echo -e "\n    Fixing: $parentlib"
         echo "    $oldlib -> $newlib"
-        install_name_tool -change $oldlib $newlib $parentlib
+        sudo install_name_tool -change $oldlib $newlib $parentlib
     done
 
     # Uncomment otool comands to have updated dynamic lib dependencies dispayed

--- a/build/macos/package.sh
+++ b/build/macos/package.sh
@@ -61,5 +61,5 @@ ARCH=$(uname -m)
     # Create MacOS disk image file
     echo -e "\nCreate .dmg file ..."
     RELEASE=$RELEASE"_"
-    hdiutil create -volname NCPA-$NCPA_VER -srcfolder NCPA-INSTALL-$NCPA_VER -ov -format UDZO ncpa_$NCPA_VER-$RELEASE$ARCH.dmg
+    sudo hdiutil create -volname NCPA-$NCPA_VER -srcfolder NCPA-INSTALL-$NCPA_VER -ov -format UDZO ncpa_$NCPA_VER-$RELEASE$ARCH.dmg
 )

--- a/build/macos/setup.sh
+++ b/build/macos/setup.sh
@@ -54,7 +54,7 @@ install_prereqs() {
     #  INSTALL PYTHON MODULES
     # --------------------------
 
-    update_py_packages >> $BUILD_DIR/build.log
+    update_py_packages | sudo tee -a $BUILD_DIR/build.log
 
     # --------------------------
     #  MISC ADDITIONS

--- a/startup/default-plist
+++ b/startup/default-plist
@@ -4,8 +4,6 @@
     <dict>
         <key>Label</key>
         <string>com.nagios.ncpa</string>
-        <key>RunAtLoad</key>
-        <true/>
         <key>WorkingDirectory</key>
         <string>/usr/local/ncpa</string>
         <key>Program</key>
@@ -15,5 +13,7 @@
             <string>/usr/local/ncpa/ncpa</string>
             <string>-n</string>
         </array>
+        <key>RunAtLoad</key>
+        <true/>
     </dict>
 </plist>


### PR DESCRIPTION
I don't really understand it that well, but I was getting I/O errors when using launchctl to load the plist and reformatting it like this fixed it.

Also Fixes Mac build Permissions issues that arose from Homebrew disallowing sudo/root while other parts of the script need sudo/root.