### PR TITLE
Fixing python version

### DIFF
--- a/build/windows/choco_prereqs.ps1
+++ b/build/windows/choco_prereqs.ps1
@@ -48,7 +48,7 @@ choco feature enable -name=exitOnRebootDetected
 if(-not (Get-Command git    -ErrorAction SilentlyContinue)){ choco install git -y }
 if(-not (Get-Command perl   -ErrorAction SilentlyContinue)){ choco install strawberryperl -y }
 if(-not (Get-Command nasm   -ErrorAction SilentlyContinue)){ choco install nasm -y }
-if(-not (Get-Command python -ErrorAction SilentlyContinue)){ choco install python --version=3.11.4 -y }
+if(-not (Get-Command python -ErrorAction SilentlyContinue)){ choco install python --version=3.11.6 -y }
 if(-not (Get-Command nsis   -ErrorAction SilentlyContinue)){ choco install nsis -y }
 
 #choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools;includeRecommended" -y


### PR DESCRIPTION
For another fix in the build, I had to specify a 3.11 python version to get the build to work properly (msvc-runtime isn't currently available with pip for 3.12), but I reverted to too old a version and Chocolatey's 3.11.4 version has OpenSSL 1.1.1u.

This updates to 3.11.6 which uses OpenSSL 3.0.11