### PR TITLE
Fixing Windows installs on some versions

### DIFF
--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -33,7 +33,7 @@ From a command prompt with Administrative priveleges run::
   cd /path/to/ncpa/build/
   build_windows.bat
 
-This will use Chocolatey to install various prerequisites for building NCPA and then build NCPA. If you have not yet built NCPA 3 on your machine, the script will likely tell you that a reboot is required/pending. This means that you need to restart your machine and then rerun the script and it will continue the installation/build processes.
+This will use Chocolatey to install various prerequisites for building NCPA and then build NCPA. If you have not yet built NCPA 3 on your machine, the script will likely tell you that a reboot is required/pending. This means that you need to restart your machine and then rerun the script and it will continue the installation/build processes. This may happen several times during the installation process.
 
 This will create a file called ``ncpa-<version>.exe`` in the ``build`` directory.
 This is the installer for NCPA and can be used to install NCPA on a Windows system.

--- a/build/build_windows.bat
+++ b/build/build_windows.bat
@@ -137,6 +137,8 @@ echo Building NCPA
 @REM     echo Pydir: %%F
 @REM   set pydir=%%F
 @REM )
+:: Set manually because of Windows 10 Pro
+:: It already has a python.exe (that links to the windows store for installing Python 3.7) that breaks the dynamic linking
 set pydir="C:\Python311\python.exe"
 Call "%pydir%" %~dp0\windows\build_ncpa.py %pydir%
 

--- a/build/build_windows.bat
+++ b/build/build_windows.bat
@@ -133,10 +133,11 @@ if ERRORLEVEL 1 goto :restore_policy
 :::: 4. Build NCPA
 :::::::::::::::::::::::
 echo Building NCPA
-FOR /F "tokens=* USEBACKQ" %%F IN (`where python`) DO (
-    echo Pydir: %%F
-  set pydir=%%F
-)
+@REM FOR /F "tokens=* USEBACKQ" %%F IN (`where python`) DO (
+@REM     echo Pydir: %%F
+@REM   set pydir=%%F
+@REM )
+set pydir="C:\Python311\python.exe"
 Call "%pydir%" %~dp0\windows\build_ncpa.py %pydir%
 
 :::::::::::::::::::::::

--- a/build/windows/choco_prereqs.ps1
+++ b/build/windows/choco_prereqs.ps1
@@ -48,9 +48,9 @@ choco feature enable -name=exitOnRebootDetected
 if(-not (Get-Command git    -ErrorAction SilentlyContinue)){ choco install git -y }
 if(-not (Get-Command perl   -ErrorAction SilentlyContinue)){ choco install strawberryperl -y }
 if(-not (Get-Command nasm   -ErrorAction SilentlyContinue)){ choco install nasm -y }
-if(-not (Get-Command python -ErrorAction SilentlyContinue)){ choco install python --version=3.11.6 -y }
 if(-not (Get-Command nsis   -ErrorAction SilentlyContinue)){ choco install nsis -y }
 
+choco install python --version=3.11.6 -y
 #choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools;includeRecommended" -y
 choco install visualstudio2022buildtools -y --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.Windows10SDK.18362"
 choco install visualstudio2022community -y --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.Windows10SDK.18362"


### PR DESCRIPTION
Windows 10 Pro has a python.exe file (which actually is a link to the windows store) that shows up when you run which python and was breaking the windows script. I've since hard-coded the path to C:\Python311\python.exe and checked that Chocolatey installed python 3.11.6 in that location on all Windows 10/11 and 10-based Server distros.