### PR TITLE
Linux installs when NCPA 2 isn't installed give errors even though it works

### DIFF
--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -52,23 +52,23 @@ rm -rf %{buildroot}
 %pre
 if which chkconfig &> /dev/null; then
     echo "Try to stop services with chkconfig"
-    /usr/local/ncpa/ncpa_listener --stop &> /dev/null
-    /usr/local/ncpa/ncpa_passive --stop &> /dev/null
+    [ -f /usr/local/ncpa/ncpa_listener ] && /usr/local/ncpa/ncpa_listener --stop &> /dev/null
+    [ -f /usr/local/ncpa/ncpa_passive ] && /usr/local/ncpa/ncpa_passive --stop &> /dev/null
     chkconfig --del ncpa_listener
     chkconfig --del ncpa_passive
 fi
 if command -v systemctl &> /dev/null
 then
     echo "Try to stop services with systemctl"
-    systemctl stop ncpa_listener &> /dev/null || true
-    systemctl stop ncpa_passive &> /dev/null || true
+    systemctl list-units --full -all | grep -Fq 'ncpa_listener.service' && systemctl stop ncpa_listener &> /dev/null || true
+    systemctl list-units --full -all | grep -Fq 'ncpa_passive.service' && systemctl stop ncpa_passive &> /dev/null || true
     systemctl stop ncpa &> /dev/null || true
 fi
 if command -v service &> /dev/null
 then
     echo "Try to stop services with service"
-    service ncpa_listener stop &> /dev/null || true
-    service ncpa_passive stop &> /dev/null || true
+    service --status-all 2>&1 | grep -Fq 'ncpa_listener' && service ncpa_listener stop &> /dev/null || true
+    service --status-all 2>&1 | grep -Fq 'ncpa_passive' && service ncpa_passive stop &> /dev/null || true
     service ncpa stop &> /dev/null || true
 fi
 


### PR DESCRIPTION
This should fix the title
Tested on:
- [x] Fedora-based 7/8/9
- [ ] Debian-based Ubu18/20/22 Deb 10/11/12
- [ ] OpenSUSE
- [ ] SLES