### PR TITLE
Fixing update

### DIFF
--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -43,7 +43,7 @@ touch %{buildroot}/usr/local/ncpa/var/ncpa.db
 chown nagios:nagios %{buildroot}/usr/local/ncpa -R
 install -m 755 $RPM_BUILD_DIR/ncpa-%{version}/build_resources/default-init %{buildroot}/etc/init.d/ncpa
 
-if [ -x `which update-rc.d` ]; then
+if which update-rc.d >/dev/null 2>&1; then
     update-rc.d -f ncpa_listener remove
     update-rc.d -f ncpa_passive remove
 fi


### PR DESCRIPTION
One of the fixes to remove NCPA 2 files was breaking the build on other distros