### PR TITLE
Removing extraneous certs from the /tmp directory on NCPA start

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 - Resolved errors appearing in Linux installs where the installation was actually successful. (Blake Bahner)
 - Enhanced build process to support Oracle Linux 8 & 9. (Blake Bahner)
 - Added a check for NCPA 2 processes in Linux builds on distributions utilizing chkconfig. (Jason Michaelson)
+- Removed extraneous certs that were being generated on restart of the NCPA service. (Blake Bahner)
 
 3.0.0 - 11/17/2023
 ==================

--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -76,6 +76,11 @@ __STARTED__ = datetime.datetime.now()
 
 options = {}
 
+if os.name == 'posix':
+    # remove extraneous certs from /tmp
+    for filepath in glob.glob(os.path.join("/tmp", "tmp*cacert.pem")):
+        os.remove(filepath)
+
 print("***** Starting NCPA version: ", __VERSION__)
 
 # About Logging


### PR DESCRIPTION
When you restart NCPA, it creates temporary certs in the /tmp folder that aren't cleaned up until system reboot. This removes them when you restart NCPA.