### PR TITLE
Altering ConfigParser instantiation to disable interpolation

### DIFF
--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -876,22 +876,17 @@ def get_configuration(config=None, configdir=None):
     """Get the configuration options and return the config parser for them"""
     parent_logger.debug("get_configuration()")
 
-    # Use default config/directory if none is given to us
-    if config is None:
-        config = os.path.join('etc', 'ncpa.cfg')
-        configdir = os.path.join('etc', 'ncpa.cfg.d', '*.cfg')
+    config = os.path.join('etc', 'ncpa.cfg')
+    configdir = os.path.join('etc', 'ncpa.cfg.d', '*.cfg')
 
-    # Get the configuration
-    config_filenames = [get_filename(config)]
-
-    # Add config directory if it is defined
-    if configdir is not None:
-        config_filenames.extend(sorted(glob.glob(get_filename(configdir))))
-
-    cp = ConfigParser()
+    cp = ConfigParser(interpolation=None)
     cp.optionxform = str
     cp.read_dict(cfg_defaults)
-    cp.read(config_filenames)
+    cp.read(get_filename(config))
+
+    if configdir is not None:
+        for config_file in sorted(glob.glob(get_filename(configdir))):
+            cp.read(config_file)
     return cp
 
 def chown(user_uid, user_gid, fn):

--- a/agent/passive/nrds.py
+++ b/agent/passive/nrds.py
@@ -97,7 +97,7 @@ class Handler(passive.nagioshandler.NagiosHandler):
                 temp_config.write(nrds_response)
                 temp_config.seek(0)
 
-                test_config = cp.ConfigParser()
+                test_config = cp.ConfigParser(interpolation=None)
                 test_config.read_file(temp_config)
 
                 if not test_config.sections():


### PR DESCRIPTION
ConfigParser's interpolation means that `%` must be escaped (`%%`) for it to register as the `%` character in the configuration. This has led several people to have issues with their passwords as they simply made them mypasswordwith% unknowingly breaking their configuration. As interpolation isn't particularly useful for this project, I will disable it by default. 

Anyone who wants it will have to find the two instances of instantiating ConfigParser and build NCPA where it instantiates it with `ConfigParser()` instead of the now `ConfigParser(interpolation=None)`

In NCPA 2, the `%` character did not need to be escaped.