### PR TITLE
Manually removing the configuration files on Debian breaks future installs

### DIFF
--- a/agent/etc/ncpa.cfg.d/example.cfg.sample
+++ b/agent/etc/ncpa.cfg.d/example.cfg.sample
@@ -1,0 +1,12 @@
+#
+#	Basic example of Passive checks being defined
+#
+
+#[passive checks]
+
+#%HOSTNAME%|__HOST__ = system/agent_version
+#%HOSTNAME%|Disk Usage = disk/logical/C:|/used_percent --warning 80 --critical 90 --units Gi
+#%HOSTNAME%|CPU Usage = cpu/percent --warning 60 --critical 80 --aggregate avg
+#%HOSTNAME%|Swap Usage = memory/swap --warning 60 --critical 80 --units Gi
+#%HOSTNAME%|Memory Usage = memory/virtual --warning 80 --critical 90 --units Gi
+#%HOSTNAME%|Process Count = processes --warning 300 --critical 400

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -119,6 +119,9 @@ mkdir -p /usr/local/ncpa/etc/ncpa.cfg.d
 if [ ! -f "/usr/local/ncpa/etc/ncpa.cfg" ]; then
     cp -p %{_datadir}/ncpa/ncpa.cfg.sample /usr/local/ncpa/etc/ncpa.cfg
 fi
+if [ ! -f "/usr/local/ncpa/etc/ncpa.cfg.d/example.cfg" ]; then
+    cp -p %{_datadir}/ncpa/ncpa.cfg.d/example.cfg /usr/local/ncpa/etc/ncpa.cfg.d/example.cfg
+fi
 
 
 if command -v systemctl &> /dev/null; then

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -111,6 +111,15 @@ dir=$RPM_INSTALL_PREFIX/ncpa
 sed -i "s|_BASEDIR_|BASEDIR=\x22$dir\x22|" /etc/init.d/ncpa
 sed -i "s|_BASEDIR_|$dir|" /usr/lib/systemd/system/ncpa.service
 
+# Create directories if they don't exist (Debian install issue if they removed them manually)
+mkdir -p /usr/local/ncpa/etc
+mkdir -p /usr/local/ncpa/etc/ncpa.cfg.d
+
+# Copy default config file if it doesn't exist
+if [ ! -f "/usr/local/ncpa/etc/ncpa.cfg" ]; then
+    cp -p %{_datadir}/ncpa/ncpa.cfg.sample /usr/local/ncpa/etc/ncpa.cfg
+fi
+
 
 if command -v systemctl &> /dev/null; then
     systemctl enable ncpa &> /dev/null

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -120,7 +120,7 @@ if [ ! -f "/usr/local/ncpa/etc/ncpa.cfg" ]; then
     cp -p %{_datadir}/ncpa/ncpa.cfg.sample /usr/local/ncpa/etc/ncpa.cfg
 fi
 if [ ! -f "/usr/local/ncpa/etc/ncpa.cfg.d/example.cfg" ]; then
-    cp -p %{_datadir}/ncpa/ncpa.cfg.d/example.cfg /usr/local/ncpa/etc/ncpa.cfg.d/example.cfg
+    cp -p %{_datadir}/ncpa/ncpa.cfg.d/example.cfg.sample /usr/local/ncpa/etc/ncpa.cfg.d/example.cfg
 fi
 
 

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -231,6 +231,7 @@ fi
 %config(noreplace) /usr/local/ncpa/etc/ncpa.cfg
 %config(noreplace) /usr/local/ncpa/etc/ncpa.cfg.d/example.cfg
 /usr/local/ncpa/etc/ncpa.cfg.sample
+/usr/local/ncpa/etc/ncpa.cfg.d/example.cfg.sample
 /usr/local/ncpa/etc/ncpa.cfg.d/README.txt
 
 %defattr(0640,root,nagios,0755)

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -115,12 +115,12 @@ sed -i "s|_BASEDIR_|$dir|" /usr/lib/systemd/system/ncpa.service
 mkdir -p /usr/local/ncpa/etc
 mkdir -p /usr/local/ncpa/etc/ncpa.cfg.d
 
-# Copy default config file if it doesn't exist
+# Copy default main config file if it doesn't exist
 if [ ! -f "/usr/local/ncpa/etc/ncpa.cfg" ]; then
-    cp -p %{_datadir}/ncpa/ncpa.cfg.sample /usr/local/ncpa/etc/ncpa.cfg
+    cp -p /usr/local/ncpa/etc/ncpa.cfg.sample /usr/local/ncpa/etc/ncpa.cfg
 fi
 if [ ! -f "/usr/local/ncpa/etc/ncpa.cfg.d/example.cfg" ]; then
-    cp -p %{_datadir}/ncpa/ncpa.cfg.d/example.cfg.sample /usr/local/ncpa/etc/ncpa.cfg.d/example.cfg
+    cp -p /usr/local/ncpa/etc/ncpa.cfg.d/example.cfg.sample /usr/local/ncpa/etc/ncpa.cfg.d/example.cfg
 fi
 
 
@@ -231,8 +231,8 @@ fi
 %config(noreplace) /usr/local/ncpa/etc/ncpa.cfg
 %config(noreplace) /usr/local/ncpa/etc/ncpa.cfg.d/example.cfg
 /usr/local/ncpa/etc/ncpa.cfg.sample
-/usr/local/ncpa/etc/ncpa.cfg.d/example.cfg.sample
 /usr/local/ncpa/etc/ncpa.cfg.d/README.txt
+/usr/local/ncpa/etc/ncpa.cfg.d/example.cfg.sample
 
 %defattr(0640,root,nagios,0755)
 /usr/lib/systemd/system/ncpa.service


### PR DESCRIPTION
If you manually remove the configuration files, it won't replace them when you install in the future even if you apt/apt-get remove ncpa. This is trying to fix that. I'm still getting a `chown` error, but the files are being replaced. I'd like to figure out and get rid of the error before merging this.