### PR TITLE
Adding ExecStopPost to service definition to remove pidfile

### DIFF
--- a/startup/default-service
+++ b/startup/default-service
@@ -5,6 +5,7 @@ After=network.target local-fs.target
 
 [Service]
 ExecStart=_BASEDIR_/ncpa -n
+ExecStopPost=/usr/bin/rm -f /usr/local/ncpa/var/run/ncpa.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Sometimes NCPA didn't delete the pid file when a server shutdown/restarted, causing NCPA to think that another instance was already running and it would fail to start.