### PR TITLE
Updating ZLib version and updating the script to use the archive so ZLib updates don't break the build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 - Added a filter to log output to remove tokens from the WSGI Server's log output. (Blake Bahner)
 - Added busy_time to the disk endpoint on posix systems to provide the percentage of time the disk is busy. (Blake Bahner)
 - Updated the bundled Python version to 3.11.8 and OpenSSL version to 3.0.13 to resolve CVEs. (Blake Bahner)
+- Updated the bundled zLib version and link so the build won't break when zLib is updated. (Blake Bahner)
 
 **Bug Fixes**
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -5,7 +5,7 @@ echo -e "***** build/build.sh"
 # Global variables
 PYTHONVER="3.11.8"
 SSLVER="3.0.13"
-ZLIBVER="1.3"
+ZLIBVER="1.3.1"
 
 UNAME=$(uname)
 if [ "$UNAME" == "Darwin" ] || [ "$UNAME" == "AIX" ] || [ "$UNAME" == "SunOS" ]; then

--- a/build/linux/installers.sh
+++ b/build/linux/installers.sh
@@ -64,7 +64,7 @@ install_zlib() {
     echo -e "Building zLib $zLib_new_version...\n"
 
     pushd /usr/src
-    wget https://zlib.net/zlib-$zLib_new_version.tar.gz --no-check-certificate
+    wget https://zlib.net/fossils/zlib-$zLib_new_version.tar.gz --no-check-certificate
     tar -zxf zlib-$zLib_new_version.tar.gz
 
     pushd zlib-$zLib_new_version


### PR DESCRIPTION
… the build will not break when zlib releases a new version
Fixes #1099 