### PR TITLE
added ExecStop to ncpa service file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 - Fixed a documentation issue where the pid file name was not updated to reflect the NCPA 3 changes. (Blake Bahner)
 - Fixed an issue where NCPA would crash if a plugin had no output. (Blake Bahner)
 - Fixed an issue where Windows logs with a different date format would fail to parse. (gittethis)
+- Fixed an issue where certain RHEL systems would fail to start NCPA on reboot. (Blake Bahner)
 
 3.0.1 - 12/13/2023
 ==================

--- a/startup/default-service
+++ b/startup/default-service
@@ -5,6 +5,7 @@ After=network.target local-fs.target
 
 [Service]
 ExecStart=_BASEDIR_/ncpa -n
+ExecStop=_BASEDIR_/ncpa --stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes issue #1068 
This shouldn't be necessary anymore given our now improved pidfile handling from MR #1107+ MR #1115, but this is a good backup to have.