### PR TITLE
Updating configuration comment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 
 - Added migration of NCPA 2 configuration files to NCPA 3. (Blake Bahner)
 - Made the NCPA 3 plugin extensions case-insensitive. (Blake Bahner)
+- Removed misleading information from the NCPA 3 configuration file. (Blake Bahner)
 
 **Bug Fixes**
 

--- a/agent/etc/ncpa.cfg
+++ b/agent/etc/ncpa.cfg
@@ -337,10 +337,6 @@ follow_symlinks = 0
 # .wsf = cscript $plugin_name $plugin_args //NoLogo
 # .bat = cmd /c $plugin_name $plugin_args
 #
-# Since windows NCPA is 32-bit, if you need to use 64-bit powershell, try the following for
-# the powershell plugin definition:
-# .ps1 = c:\windows\sysnative\windowspowershell\v1.0\powershell.exe -ExecutionPolicy Unrestricted -File $plugin_name $plugin_args
-#
 
 # Linux / Mac OS X
 .sh = /bin/sh $plugin_name $plugin_args

--- a/agent/etc/ncpa.cfg.sample
+++ b/agent/etc/ncpa.cfg.sample
@@ -337,10 +337,6 @@ follow_symlinks = 0
 # .wsf = cscript $plugin_name $plugin_args //NoLogo
 # .bat = cmd /c $plugin_name $plugin_args
 #
-# Since windows NCPA is 32-bit, if you need to use 64-bit powershell, try the following for
-# the powershell plugin definition:
-# .ps1 = c:\windows\sysnative\windowspowershell\v1.0\powershell.exe -ExecutionPolicy Unrestricted -File $plugin_name $plugin_args
-#
 
 # Linux / Mac OS X
 .sh = /bin/sh $plugin_name $plugin_args


### PR DESCRIPTION
There was a section in the configuration where it said to use the 32-bit PowerShell, but this was for NCPA 2 and no longer applies.