### PR TITLE
Improves/fixes passive checks to use CLI-style splitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 - Added migration of NCPA 2 configuration files to NCPA 3. (Blake Bahner)
 - Made the NCPA 3 plugin extensions case-insensitive. (Blake Bahner)
 - Removed misleading information from the NCPA 3 configuration file. (Blake Bahner)
+- Updated passive checks to allow escaped spaces. (Blake Bahner)
 
 **Bug Fixes**
 

--- a/agent/passive/ncpacheck.py
+++ b/agent/passive/ncpacheck.py
@@ -4,6 +4,7 @@ import time
 import hashlib
 import listener.server
 import listener.database as database
+import shlex
 from ncpa import passive_logger as logging
 
 
@@ -206,7 +207,7 @@ class NCPACheck(object):
         """
         logging.debug("Parsing command line style instruction: %s",
                       instruction)
-        stripped_instruction = instruction.strip().split(' ')
+        stripped_instruction = shlex.split(instruction.strip())
 
         api_url = stripped_instruction[0]
         api_args = {}


### PR DESCRIPTION
The following passive check examples will now work properly:
- `%HOSTNAME%|my check = plugins/my\ plugin.sh args="test args"`
- `%HOSTNAME%|my check = plugins/"my plugin.sh" args="test args"`