### PR TITLE
fix: Only chown logfile if it exists

### DIFF
--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -1175,7 +1175,7 @@ def main(has_error):
         log = logging.getLogger()
         log.setLevel('DEBUG')
 
-        p, l = start_processes(options, config, has_error, True)
+        p, l = start_processes(options, config, has_error)
 
         # Wait for exit
         print("Running in Debug Mode (https://localhost:5700/)\nPress enter to exit...\n", flush = True)

--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -1031,7 +1031,7 @@ def setup_logger(config, loggerinstance, logfile):
             max_log_size_bytes = logmaxmb * 1024 * 1024
             handlers.append(RotatingFileHandler(logfile, maxBytes=max_log_size_bytes, backupCount=logbackups))
 
-        if __SYSTEM__ == 'posix':
+        if __SYSTEM__ == 'posix' and os.path.isfile(logfile):
             chown(config.get('general', 'uid'), config.get('general', 'gid'), logfile)
 
     loggerinstance.setLevel(level)


### PR DESCRIPTION
When the logfile doesn't exist the agent shows an error: `PermissionError: [Errno 13] Permission denied: '/var/log/ncpa_passive.log'`

This PR fixes that by only `chown`ing if the file exists.

It also fixes the debug mode that used to crash due to an unknown parameter.