### PR TITLE
Updating spec files to use SHA256 for FIPS install

### DIFF
--- a/build/aix/ncpa.spec
+++ b/build/aix/ncpa.spec
@@ -1,3 +1,6 @@
+%define _source_filedigest_algorithm 8
+%define _binary_filedigest_algorithm 8
+
 Name:           ncpa
 Version:        __VERSION__
 Release:        1

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -1,3 +1,6 @@
+%define _source_filedigest_algorithm 8
+%define _binary_filedigest_algorithm 8
+
 Name:           ncpa
 Version:        __VERSION__
 Release:        1

--- a/build/linux/suse-ncpa.spec
+++ b/build/linux/suse-ncpa.spec
@@ -1,3 +1,6 @@
+%define _source_filedigest_algorithm 8
+%define _binary_filedigest_algorithm 8
+
 Name:           ncpa
 Version:        __VERSION__
 Release:        1.sle15


### PR DESCRIPTION
Fixes #1168

Note: More will need to be done to get it actually working on FIPS-mode enabled machines, but this does make the install go through while FIPS is enabled.