### PR TITLE
Temporary cx_Freeze version selection to fix build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,13 @@ Changelog
 ==================
 **Updates**
 
-- Updated OpenSSL on Linux builds to OpenSSL 3.0.14 to resolve some CVEs. [GH#1176] (Blake Bahner)
+- Updated OpenSSL on Linux builds to OpenSSL 3.0.14 to resolve some CVEs. [GH:#1176] (Blake Bahner)
 
 **Bug Fixes**
 
 - Fixed an issue where NCPA would show an error if the logs were missing. (Ivan-Roger)
 - Fixed an issue that would cause NCPA to crash in debug mode due to a wrongly called function. (Ivan-Roger)
+- Fixed an issue where new NCPA builds would fail because of a cx_Freeze update. [GH:#1177,#1178] (Blake Bahner)
 
 3.1.0 - 05/16/2024
 ==================

--- a/build/resources/require.txt
+++ b/build/resources/require.txt
@@ -1,4 +1,4 @@
-cx_Freeze
+cx_Freeze==6.15.16
 psutil
 requests
 Jinja2

--- a/build/resources/require.win.txt
+++ b/build/resources/require.win.txt
@@ -1,4 +1,4 @@
-cx_Freeze
+cx_Freeze==6.15.16
 cx_Logging
 psutil
 requests


### PR DESCRIPTION
Temporarily setting the cx_Freeze version to `6.15.16` until I can figure out what needs to be updated to get the build working with cx_Freeze 7.