### PR TITLE
Updating the OpenSSL link to use the Github source instead of the OpenSSL.org source

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 ==================
 **Updates**
 
-- Updated OpenSSL on Linux builds to OpenSSL 3.0.14 to resolve some CVEs. [GH:#1176] (Blake Bahner)
+- Updated OpenSSL on Linux builds to OpenSSL 3.0.15 to resolve some CVEs. [GH:#1176] (Blake Bahner)
 - Updated Python to 3.12.5 for Windows builds to resolve some CVEs. (Blake Bahner)
 - Updated the RPM hash to SHA256 to enable the installation of NCPA in FIPS mode. [GH:#1168] (Blake Bahner)
 

--- a/build/linux/installers.sh
+++ b/build/linux/installers.sh
@@ -123,7 +123,7 @@ install_openssl() {
 
     pushd /usr/src
 
-    wget https://www.openssl.org/source/openssl-$ssl_new_version.tar.gz --no-check-certificate
+    wget https://www.github.com/openssl/openssl/releases/download/openssl-$ssl_new_version/openssl-$ssl_new_version.tar.gz --no-check-certificate
     tar -zxf openssl-$ssl_new_version.tar.gz
 
     pushd openssl-$ssl_new_version


### PR DESCRIPTION
For OpenSSL 3.0.15, it is available on the OpenSSL.org website, but instead of hosting it themselves, they just link to their GitHub, so I am updating our script for grabbing the OpenSSL version to grab from the GitHub repo.