### PR TITLE
Upgrading Windows build to Python 3.13.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 3.1.2 - 01/XX/2025
 ==================
 **Updates**
+- Updated Python to 3.13.1 on Windows builds to resolve some CVEs. (Blake Bahner)
 
 **Bug Fixes**
 

--- a/build/build_windows.bat
+++ b/build/build_windows.bat
@@ -139,8 +139,8 @@ echo Building NCPA
 @REM )
 :: Set manually because of Windows 10 Pro
 :: It already has a python.exe (that links to the windows store for installing Python 3.7) that breaks the dynamic linking
-set pydir="C:\Python312\python.exe"
-Call "%pydir%" "%~dp0\windows\build_ncpa.py %pydir%"
+set pydir="C:\Python313\python.exe"
+Call "%pydir%" "%~dp0\windows\build_ncpa.py" "%pydir%"
 
 :::::::::::::::::::::::
 :::: 5. Restore original execution policy

--- a/build/resources/require.win.txt
+++ b/build/resources/require.win.txt
@@ -1,4 +1,4 @@
-cx_Freeze
+cx_Freeze==7.3.0.2759.dev1735527159
 cx_Logging
 psutil
 requests

--- a/build/windows/choco_prereqs.ps1
+++ b/build/windows/choco_prereqs.ps1
@@ -50,7 +50,7 @@ if(-not (Get-Command perl   -ErrorAction SilentlyContinue)){ choco install straw
 if(-not (Get-Command nasm   -ErrorAction SilentlyContinue)){ choco install nasm -y }
 if(-not (Get-Command nsis   -ErrorAction SilentlyContinue)){ choco install nsis -y }
 
-choco install python --version=3.12.6 -y --force
+choco install python --version=3.13.1 -y --force
 #choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools;includeRecommended" -y
 choco install visualstudio2022buildtools -y --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.Windows10SDK.18362"
 choco install visualstudio2022community -y --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.Windows10SDK.18362"


### PR DESCRIPTION
NOTE: we need to use a development version of cx_Freeze to use Python 3.13. I have done preliminary testing and have encountered no issues with this so far. As soon as cx_Freeze 7.3 is officially released, we will update require.win.txt to use the most up-to-date version of cx_Freeze.