### PR TITLE
Adding interface status to the interface endpoint.

### DIFF
--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -223,6 +223,16 @@ def make_if_nodes(if_name):
     dropin = RunnableNode("dropin", method=lambda: (x[if_name].dropin, "packets"))
     dropout = RunnableNode("dropout", method=lambda: (x[if_name].dropout, "packets"))
 
+    ifs = ps.net_if_stats()
+    if if_name in ifs:
+        if ifs[if_name].isup:
+            status = "up"
+        else:
+            status = "down"
+    else:
+        status = "unknown"
+    statusNode = RunnableNode("status", method=lambda: (status, ""))
+
     return RunnableParentNode(
         if_name,
         primary="bytes_sent",
@@ -235,6 +245,7 @@ def make_if_nodes(if_name):
             dropout,
             bytes_sent,
             errout,
+            statusNode,
         ],
     )
 


### PR DESCRIPTION
Since the NCPA wizard already splits the interface endpoint into multiple checks, this won't break any XI perfdata.
Also reworks the `get_interface_node()` and `make_if_nodes()` to be more efficient (only calls ps.net_io_counters once now)