### PR TITLE
Issue-1217: Convert return code to string before passing to make_tag()

### DIFF
--- a/agent/passive/nrdp.py
+++ b/agent/passive/nrdp.py
@@ -66,7 +66,7 @@ class Handler(passive.nagioshandler.NagiosHandler):
 
         check_result = Handler.make_tag('checkresult', tag_attr={'type': check_type})
         hostname = Handler.make_tag('hostname', check.hostname)
-        state = Handler.make_tag('state', returncode)
+        state = Handler.make_tag('state', str(returncode))
         output = Handler.make_tag('output', stdout)
 
         if not check_type == 'host':


### PR DESCRIPTION
Fixes #1217 

before the patch:
```
2025-02-20 13:48:44,035 passive DEBUG XML to be submitted: <?xml version="1.0" ?><checkresults><checkresult type="service"><servicename>http_google</servicename><hostname>www.google.com</hostname><state/><output>HTTP OK: HTTP/1.1 200 OK - 19356 bytes in 0.0645 second response time |time=0.06454s;;;0.000000;10.000000 size=19356B;;;0;</output></checkresult></checkresults>
```

after the patch:
```
2025-02-20 13:54:59,044 passive DEBUG XML to be submitted: <?xml version="1.0" ?><checkresults><checkresult type="service"><servicename>http_google</servicename><hostname>www.google.com</hostname><state>0</state><output>HTTP OK: HTTP/1.1 200 OK - 19356 bytes in 0.075 second response time |time=0.075195s;;;0.000000;10.000000 size=19356B;;;0;</output></checkresult></checkresults>
```