### PR TITLE
Fix to allow run as nagios check to work again in services API

### DIFF
--- a/agent/listener/services.py
+++ b/agent/listener/services.py
@@ -375,25 +375,16 @@ class ServiceNode(listener.nodes.LazyNode):
                     builder = '%s (should be %s)' % (builder, ''.join(target_status))
 
                 # Remove each service that has a status from the list of services the user provided
-                # decode line if it's bytes
-                if isinstance(line, bytes):
-                    line = line.decode()
-                ls = line.split()
-                if len(ls) < 2:
-                    continue
-                # Skip lrc items
-                item = ls[1]
-                if 'lrc:/' in item:
-                    continue
+                # so that we can display the services that can't be found ... this only works with
+                # exact match lists of services
+                if filtered_services:
+                    i = filtered_services.index(service)
+                    filtered_services.pop(i)
 
-                sub = ls[1].replace('svc:/', '').replace('/', '|')
-                service_status = ls[0]
-                if service_status == 'online':
-                    services[sub] = 'running'
-                elif 'offline' in service_status or service_status == 'maintenance' or service_status == 'disabled':
-                    services[sub] = 'stopped'
-                else:
-                    services[sub] = 'unknown'
+                if priority > returncode:
+                    returncode = priority
+
+                stdout_builder.append({ 'info': builder, 'priority': priority })
             if returncode > 0:
                 returncode = 2
 


### PR DESCRIPTION
The ability for XI to check that a specific service is running gives back a 500 server error currently with NCPA dev-v3.2.1. This happens in XI when running the service check and also in the API on the NCPA client when you check the box to "Run as a Nagios check".

It looks like this code was probably replaced by accident in dev-v3.2.1.

This change reverts run_check() method in the services API to what it was before 3.2.1.

