### PR TITLE
Revert psutil version to 7.0.0 for Solaris build until wheel build issues are resolved.

### DIFF
--- a/build/resources/require-solaris.txt
+++ b/build/resources/require-solaris.txt
@@ -1,5 +1,5 @@
 cx_Freeze
-psutil
+psutil==7.0.0
 requests
 Jinja2
 flask


### PR DESCRIPTION
This will fix the build issue on Solaris 11.4.81.193.1 due to psutil updating to a newer version in September.