### PR TITLE
Remove quote stripping from community_string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,10 +6,6 @@ Changelog
 
 - Added option to hide running processes from output of process check command for improved performance and security. [GH#:933,#GH:#750,GL-XI:#1328] - CPD
 
-**Updates**
-
-- Update community_strings to support quote wrapping for improved security. [GH#:1319] - CPD
-
 **Bug Fixes** 
 
 - Fixed a Solaris incorrect directory permission preventing passive checks from working. [GH#1323] - chrisdeubank, CPD

--- a/agent/listener/server.py
+++ b/agent/listener/server.py
@@ -181,20 +181,6 @@ def secure_compare(item1, item2):
     return compare_digest(item1, item2)
 
 
-def strip_if_quoted(s):
-    """
-    Strips the outer layer of quotes from a string if it is fully wrapped 
-    in a matching pair of single or double quotes.
-    """
-    if isinstance(s, str):
-        if len(s) >= 2:
-            if (s.startswith('\'') and s.endswith('\'')) or \
-            (s.startswith('"') and s.endswith('"')):
-                # Slice the string to remove the first and last characters
-                return s[1:-1]
-    return s
-
-
 # ------------------------------
 # Authentication Wrappers
 # ------------------------------
@@ -330,9 +316,7 @@ def requires_token_or_auth(f):
     def token_auth_decoration(*args, **kwargs):
         ncpa_token = listener.config['iconfig'].get('api', 'community_string')
         token = request.values.get('token', None)
-        # Remove any surrounding quotes
-        stripped_token = strip_if_quoted(token)
-        token_valid = secure_compare(stripped_token, ncpa_token)
+        token_valid = secure_compare(token, ncpa_token)
 
         # This is an internal call, we don't check
         if __INTERNAL__ is True:


### PR DESCRIPTION
This will remove the quote stripping feature as we are moving in a different direction to deal with special chars in community_strings.