### PR TITLE
Clear run as nagios checkbox when changing endpoints in webui API browser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 - Fixed a Solaris incorrect directory permission preventing passive checks from working. [GH#1323] - chrisdeubank, CPD
 - Fixed a Solaris issue where NCPA service removal would leave behind masked services. [GH#1298] - chrisdeubank, CPD
 - Fixed a Linux permission issue preventing passive SSL certificate verification from working. [GH#1321, GH#1279] - CPD
+- Fixed an issue where the run as nagios checkbox in the API browser would not clear when changing endpoints in the dropdown. [GH#1332] - CPD
 
 3.2.2 - 12/11/2025
 ==================

--- a/agent/listener/templates/gui/api.html
+++ b/agent/listener/templates/gui/api.html
@@ -729,8 +729,8 @@ function toggle_check_ncpa_btn() {
 
 function clear_settings() {
     $('.settings input[type="checkbox"]').attr('checked', false);
+    // Uncheck run as nagios check box when clearing settings
     if ($('input.check').is(':checked')) {
-        // uncheck the check box
         $('input.check').prop('checked', false);
     } 
     $('.settings input').val('');


### PR DESCRIPTION
Fixes a bug where the checkbox stays checked, even though it is no longer visible when changing endpoints from the dropdown menu.

Closes #1332