### PR TITLE
Undo Solaris change that adds CPU specific python lib paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,6 @@ Changelog
 **Bug Fixes** 
 
 - Fixed an issue on MacOS systems where the services endpoint was not working correctly. [GH#669] - CPD
-- Fixed missing python shared library on Solaris builds causing NCPA to not start without python-313 installed. [GH#1308] - CPD
 - Fixed an issue where a duplicate navbar would render on the admin/plugin-directives page. [GH#1167] - CPD
 
 3.2.3 - 1/22/2026

--- a/build/version_config.py
+++ b/build/version_config.py
@@ -126,8 +126,6 @@ def get_solaris_lib_paths():
     # Try to find the Python library in IPS locations first (preferred)
     python_lib_found = False
     for python_lib_path in [
-        f'/usr/lib/amd64/libpython{actual_python_version}.so*',
-        f'/usr/lib/sparcv9/libpython{actual_python_version}.so*',
         f'/usr/lib/python{actual_python_version}/config-{actual_python_version}*/libpython{actual_python_version}.so*',
         f'/usr/lib/libpython{actual_python_version}.so*',
         f'/usr/local/lib/libpython{actual_python_version}.so*'


### PR DESCRIPTION
This seemed like it was working as expected on Solaris x86_64 test systems, but not linking correctly when tested on a SPARC system.

I am reverting the change for now, as it did not seem to resolve issue of the missing libpython3.13.so.1 for SPARC.