### PR TITLE
Fix to stop warning message from python dependency

### DIFF
--- a/build/resources/require.txt
+++ b/build/resources/require.txt
@@ -13,3 +13,4 @@ cffi
 appdirs
 packaging
 kafka-python
+charset-normalizer==3.4.4


### PR DESCRIPTION
Apparently there was an update to a dependency for the Python Requests library that is causing a new warning message to pop up in strange places like /var/log/messages, and when you uninstall NCPA for some reason.

`requests/__init__.py:86: RequestsDependencyWarning: Unable to find acceptable character detection dependency (chardet or charset_normalizer).`

This is hopefully a temporary fix.