### PR TITLE
Change wording for service cleanup messages

### DIFF
--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -219,17 +219,17 @@ then
 
     # Check if the link exists AND its target does not exist
     if [[ -L "$LINK_PATH/ncpa_listener.service" && ! -e "$LINK_PATH/ncpa_listener.service" ]]; then
-        echo "'$LINK_PATH/ncpa_listener.service' is a broken symbolic link."
+        echo "'$LINK_PATH/ncpa_listener.service' - removing stale symbolic link."
         rm -f "$LINK_PATH/ncpa_listener.service"
     fi
 
     if [[ -L "$LINK_PATH/ncpa_passive.service" && ! -e "$LINK_PATH/ncpa_passive.service" ]]; then
-        echo "'$LINK_PATH/ncpa_passive.service' is a broken symbolic link."
+        echo "'$LINK_PATH/ncpa_passive.service' - removing stale symbolic link."
         rm -f "$LINK_PATH/ncpa_passive.service"
     fi
 
     if [[ -L "$LINK_PATH/ncpa.service" && ! -e "$LINK_PATH/ncpa.service" ]]; then
-        echo "'$LINK_PATH/ncpa.service' is a broken symbolic link."
+        echo "'$LINK_PATH/ncpa.service' - removing stale symbolic link."
         rm -f "$LINK_PATH/ncpa.service"
     fi
 fi


### PR DESCRIPTION
Changing the wording to be more descriptive why the user is seeing this message.

This should really only pop up on systems where NCPA was upgraded from a 2.x version to a 3.x version and then someone uninstalls the 3.x version.