### PR TITLE
Add default text value for the NCPA token in the Windows installer 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 ==================
 **Added**
 
-- Placeholder for future release updates. - CPD
+- Added a default token value to the Windows installer to prevent the token from being blank after installation. - CPD
 
 3.3.1 - 3/19/2026
 ==================

--- a/build/resources/nsis_listener_options.ini
+++ b/build/resources/nsis_listener_options.ini
@@ -78,6 +78,7 @@ Flags=DISABLED
 
 [Field 10]
 Type=Text
+State=mytoken
 Left=34
 Right=286
 Top=57


### PR DESCRIPTION
This fixes an issue where the token could be set to empty if no text is added while running the NCPA Windows installer.