### PR TITLE
Remove redundant Python executable from the install

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
 
 **Updates**
 
-- Removed redundant Python executables from the install to reduce potential attack surface and confusion. - CPD
+- Removed redundant Python executable from the install to reduce potential attack surface and confusion. - CPD
 
 3.3.1 - 3/19/2026
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changelog
 
 - Placeholder for future release updates. - CPD
 
+**Updates**
+
+- Removed redundant Python executables from the install to reduce potential attack surface and confusion. - CPD
+
 3.3.1 - 3/19/2026
 ==================
 **Added**

--- a/agent/setup.py
+++ b/agent/setup.py
@@ -63,8 +63,7 @@ if __SYSTEM__ == 'nt':
                      ('../build/resources/ncpa.ico'                     , 'build_resources/ncpa.ico'),
                      ('../build/resources/nagios_installer.bmp'         , 'build_resources/nagios_installer.bmp'),
                      ('../build/resources/nagios_installer_logo.bmp'    , 'build_resources/nagios_installer_logo.bmp'),
-                     ('../build/resources/ncpa.nsi'                     , 'build_resources/ncpa.nsi'),
-                     (sys.executable                                    , 'python.exe')]
+                     ('../build/resources/ncpa.nsi'                     , 'build_resources/ncpa.nsi')]
 
     # include pywin32 modules
     packages += ['win32serviceutil', 'win32service', 'win32event', 'servicemanager', 'win32timezone']
@@ -79,8 +78,7 @@ elif __SYSTEM__ == 'posix':
 
     include_files += [('../startup/default-plist'   , 'build_resources/default-plist'),
                       ('../startup/default-init'    , 'build_resources/default-init'),
-                      ('../startup/default-service' , 'build_resources/default-service'),
-                      (os.path.join(sys.executable) , 'python')]
+                      ('../startup/default-service' , 'build_resources/default-service')]
 
     # Shared library include overrides
     bin_includes += get_linux_lib_includes()


### PR DESCRIPTION
I do not believe it is necessary to include a copy of the Python executable in the install of NCPA since the Python interpreter is already built-in to the NCPA binary created by cx_Freeze. Unless there is some other use for this that I am not aware of, I think we should remove it.

Perhaps at one point this was necessary for the build process, but it seems like now this is a source of confusion and probably a potential attack vector.

The Python exe is already excluded from the Linux & AIX builds by not adding it to the spec file (which it warns about), and the Solaris build explicitly removes it.

I have tested this change to confirm it does not affect the behavior of the build or install in:
- Linux
- Windows
- MacOS
- Solaris
