### PR TITLE
Fixed interface/device/status endpoint invalid string found in perfdata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changelog
 
 - Added a default token value to the Windows installer to prevent the token from being blank after installation. - CPD
 
+**Bug Fixes**
+
+- Fixed an issue where the interface/device/status endpoint was returning a string in the perfdata instead of a relevant numeric exit code. [GH#1371] - CPD
+
 3.3.1 - 3/19/2026
 ==================
 **Added**

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -523,7 +523,7 @@ class RunnableNode(ParentNode):
                 readable_text = "up"
             elif values[0] == 2:
                 readable_text = "down"
-            else values[0] == 3:
+            else:
                 readable_text = "unknown"
 
              custom_output = proper_name + " is " + readable_text

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -513,6 +513,8 @@ class RunnableNode(ParentNode):
 
         # Debug log self object
         listener_logger.debug("RunnableNode object: %r", self.__dict__)
+        # Debug log the values
+        listener_logger.debug("Values for %s: %r", proper_name, values)
 
         # Hack in the interface status change because we can't do much else...
         # if self.name == "status":

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -518,7 +518,15 @@ class RunnableNode(ParentNode):
 
         # Hack in the interface status change because we can't do much else...
         if self.name == "status":
-             custom_output = proper_name + " is " + str(values[0])
+            # Replace 0 with up, 2 with down and 3 with unknown for the info line
+            if values[0] == 0:
+                readable_text = "up"
+            elif values[0] == 2:
+                readable_text = "down"
+            else values[0] == 3:
+                readable_text = "unknown"
+
+             custom_output = proper_name + " is " + readable_text
              values_for_info_line = ""
 
         if secondary_data is True:

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -511,6 +511,19 @@ class RunnableNode(ParentNode):
             custom_output = proper_name + " was " + self.elapsed_time(values[0])
             values_for_info_line = ""
 
+        # Hack in the interface status change because we can't do much else...
+        if self.name == "status":
+            # Replace 0 with up, 2 with down and 3 with unknown for the info line
+            if values[0] == 0:
+                values_for_info_line = "up"
+            elif values[0] == 2:
+                values_for_info_line = "down"
+            else values[0] == 3:
+                values_for_info_line = "unknown"
+            # Also change the custom output to show the status instead of the numeric value
+            custom_output = proper_name + " is " + values_for_info_line
+            values_for_info_line = ""
+
         if secondary_data is True:
             stdout = "%s: %s" % (proper_name, values_for_info_line)
         else:

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -511,18 +511,21 @@ class RunnableNode(ParentNode):
             custom_output = proper_name + " was " + self.elapsed_time(values[0])
             values_for_info_line = ""
 
+        # Debug log self object
+        listener_logger.debug("RunnableNode object: %r", self.__dict__)
+
         # Hack in the interface status change because we can't do much else...
-        if self.name == "status":
-            # Replace 0 with up, 2 with down and 3 with unknown for the info line
-            if values[0] == 0:
-                readable_text = "up"
-            elif values[0] == 2:
-                readable_text = "down"
-            else values[0] == 3:
-                readable_text = "unknown"
-            # Also change the custom output to show the status instead of the numeric value
-            custom_output = proper_name + " is " + readable_text
-            values_for_info_line = ""
+        # if self.name == "status":
+        #     # Replace 0 with up, 2 with down and 3 with unknown for the info line
+        #     if values[0] == 0:
+        #         readable_text = "up"
+        #     elif values[0] == 2:
+        #         readable_text = "down"
+        #     else values[0] == 3:
+        #         readable_text = "unknown"
+        #     # Also change the custom output to show the status instead of the numeric value
+        #     custom_output = proper_name + " is " + readable_text
+        #     values_for_info_line = ""
 
         if secondary_data is True:
             stdout = "%s: %s" % (proper_name, values_for_info_line)

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -517,17 +517,9 @@ class RunnableNode(ParentNode):
         listener_logger.debug("Values for %s: %r", proper_name, values)
 
         # Hack in the interface status change because we can't do much else...
-        # if self.name == "status":
-        #     # Replace 0 with up, 2 with down and 3 with unknown for the info line
-        #     if values[0] == 0:
-        #         readable_text = "up"
-        #     elif values[0] == 2:
-        #         readable_text = "down"
-        #     else values[0] == 3:
-        #         readable_text = "unknown"
-        #     # Also change the custom output to show the status instead of the numeric value
-        #     custom_output = proper_name + " is " + readable_text
-        #     values_for_info_line = ""
+        if self.name == "status":
+             custom_output = proper_name + " is " + values[0]
+             values_for_info_line = ""
 
         if secondary_data is True:
             stdout = "%s: %s" % (proper_name, values_for_info_line)

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -512,17 +512,17 @@ class RunnableNode(ParentNode):
             values_for_info_line = ""
 
         # Hack in the interface status change because we can't do much else...
-        if self.name == "status":
-            # Replace 0 with up, 2 with down and 3 with unknown for the info line
-            if values[0] == 0:
-                readable_text = "up"
-            elif values[0] == 2:
-                readable_text = "down"
-            else values[0] == 3:
-                readable_text = "unknown"
-            # Also change the custom output to show the status instead of the numeric value
-            custom_output = proper_name + " is " + readable_text
-            values_for_info_line = ""
+        # if self.name == "status":
+        #     # Replace 0 with up, 2 with down and 3 with unknown for the info line
+        #     if values[0] == 0:
+        #         readable_text = "up"
+        #     elif values[0] == 2:
+        #         readable_text = "down"
+        #     else values[0] == 3:
+        #         readable_text = "unknown"
+        #     # Also change the custom output to show the status instead of the numeric value
+        #     custom_output = proper_name + " is " + readable_text
+        #     values_for_info_line = ""
 
         if secondary_data is True:
             stdout = "%s: %s" % (proper_name, values_for_info_line)

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -523,10 +523,8 @@ class RunnableNode(ParentNode):
                 readable_text = "up"
             elif values[0] == 2:
                 readable_text = "down"
-            elif values[0] == 3:
-                readable_text = "unknown"
             else:
-                readable_text = str(values[0])
+                readable_text = "unknown"
             # Display custom text for the status change in the info line
             custom_output = proper_name + " is " + readable_text
             values_for_info_line = ""

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -512,17 +512,17 @@ class RunnableNode(ParentNode):
             values_for_info_line = ""
 
         # Hack in the interface status change because we can't do much else...
-        # if self.name == "status":
-        #     # Replace 0 with up, 2 with down and 3 with unknown for the info line
-        #     if values[0] == 0:
-        #         readable_text = "up"
-        #     elif values[0] == 2:
-        #         readable_text = "down"
-        #     else values[0] == 3:
-        #         readable_text = "unknown"
-        #     # Also change the custom output to show the status instead of the numeric value
-        #     custom_output = proper_name + " is " + readable_text
-        #     values_for_info_line = ""
+        if self.name == "status":
+            # Replace 0 with up, 2 with down and 3 with unknown for the info line
+            if values == 0:
+                readable_text = "up"
+            elif values == 2:
+                readable_text = "down"
+            else values == 3:
+                readable_text = "unknown"
+            # Also change the custom output to show the status instead of the numeric value
+            custom_output = proper_name + " is " + values_for_info_line
+            values_for_info_line = ""
 
         if secondary_data is True:
             stdout = "%s: %s" % (proper_name, values_for_info_line)

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -514,14 +514,14 @@ class RunnableNode(ParentNode):
         # Hack in the interface status change because we can't do much else...
         if self.name == "status":
             # Replace 0 with up, 2 with down and 3 with unknown for the info line
-            if values == 0:
+            if values[0] == 0:
                 readable_text = "up"
-            elif values == 2:
+            elif values[0] == 2:
                 readable_text = "down"
-            else values == 3:
+            else values[0] == 3:
                 readable_text = "unknown"
             # Also change the custom output to show the status instead of the numeric value
-            custom_output = proper_name + " is " + values_for_info_line
+            custom_output = proper_name + " is " + readable_text
             values_for_info_line = ""
 
         if secondary_data is True:

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -519,7 +519,6 @@ class RunnableNode(ParentNode):
         # Hack in the interface status change because we can't do much else...
         if self.name == "status":
             # Replace 0 with up, 2 with down and 3 with unknown for the info line
-            readable_text = ""
             if values[0] == 0:
                 readable_text = "up"
             elif values[0] == 2:
@@ -528,9 +527,9 @@ class RunnableNode(ParentNode):
                 readable_text = "unknown"
             else:
                 readable_text = str(values[0])
-
-             custom_output = proper_name + " is " + readable_text
-             values_for_info_line = ""
+            # Display custom text for the status change in the info line
+            custom_output = proper_name + " is " + readable_text
+            values_for_info_line = ""
 
         if secondary_data is True:
             stdout = "%s: %s" % (proper_name, values_for_info_line)

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -519,6 +519,7 @@ class RunnableNode(ParentNode):
         # Hack in the interface status change because we can't do much else...
         if self.name == "status":
             # Replace 0 with up, 2 with down and 3 with unknown for the info line
+            readable_text = ""
             if values[0] == 0:
                 readable_text = "up"
             elif values[0] == 2:

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -523,8 +523,10 @@ class RunnableNode(ParentNode):
                 readable_text = "up"
             elif values[0] == 2:
                 readable_text = "down"
-            else:
+            elif values[0] == 3:
                 readable_text = "unknown"
+            else:
+                readable_text = str(values[0])
 
              custom_output = proper_name + " is " + readable_text
              values_for_info_line = ""

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -513,14 +513,14 @@ class RunnableNode(ParentNode):
 
         # Hack in the interface status change because we can't do much else...
         if self.name == "status":
-            # Replace 0 with up, 2 with down and 3 with unknown for the info line
+            # Replace 0 with up, 2 with down and 3 with unknown
             if values[0] == 0:
                 readable_text = "up"
             elif values[0] == 2:
                 readable_text = "down"
             else:
                 readable_text = "unknown"
-            # Display custom text for the status change in the info line
+            # Display custom text for the status change
             custom_output = proper_name + " is " + readable_text
             values_for_info_line = ""
 

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -511,11 +511,6 @@ class RunnableNode(ParentNode):
             custom_output = proper_name + " was " + self.elapsed_time(values[0])
             values_for_info_line = ""
 
-        # Debug log self object
-        listener_logger.debug("RunnableNode object: %r", self.__dict__)
-        # Debug log the values
-        listener_logger.debug("Values for %s: %r", proper_name, values)
-
         # Hack in the interface status change because we can't do much else...
         if self.name == "status":
             # Replace 0 with up, 2 with down and 3 with unknown for the info line

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -518,7 +518,7 @@ class RunnableNode(ParentNode):
 
         # Hack in the interface status change because we can't do much else...
         if self.name == "status":
-             custom_output = proper_name + " is " + values[0]
+             custom_output = proper_name + " is " + str(values[0])
              values_for_info_line = ""
 
         if secondary_data is True:

--- a/agent/listener/nodes.py
+++ b/agent/listener/nodes.py
@@ -515,13 +515,13 @@ class RunnableNode(ParentNode):
         if self.name == "status":
             # Replace 0 with up, 2 with down and 3 with unknown for the info line
             if values[0] == 0:
-                values_for_info_line = "up"
+                readable_text = "up"
             elif values[0] == 2:
-                values_for_info_line = "down"
+                readable_text = "down"
             else values[0] == 3:
-                values_for_info_line = "unknown"
+                readable_text = "unknown"
             # Also change the custom output to show the status instead of the numeric value
-            custom_output = proper_name + " is " + values_for_info_line
+            custom_output = proper_name + " is " + readable_text
             values_for_info_line = ""
 
         if secondary_data is True:

--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -230,11 +230,11 @@ def make_if_nodes(if_name, io_counters, if_stats):
 
     if if_name in if_stats:
         if if_stats[if_name].isup:
-            status = 1
-        else:
             status = 0
+        else:
+            status = 2
     else:
-        status = "unknown"
+        status = 3
     statusNode = RunnableNode("status", method=lambda: (status, ""))
 
     return RunnableParentNode(

--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -440,6 +440,8 @@ def get_interface_node():
     if_children = [
         make_if_nodes(if_name, io_counters, if_stats) for if_name in io_counters.keys()
     ]
+
+    logging.debug("Child data for interfaces: %s", if_children)
     return ParentNode("interface", children=if_children)
 
 

--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -230,12 +230,15 @@ def make_if_nodes(if_name, io_counters, if_stats):
 
     if if_name in if_stats:
         if if_stats[if_name].isup:
-            status = 0
+            status = "up"
+            numeric_status = 0
         else:
-            status = 2
+            status = "down"
+            numeric_status = 2
     else:
-        status = 3
-    statusNode = RunnableNode("status", method=lambda: (status, ""))
+        status = "unknown"
+        numeric_status = 3
+    statusNode = RunnableNode("status", method=lambda: (numeric_status, status))
 
     return RunnableParentNode(
         if_name,

--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -230,15 +230,12 @@ def make_if_nodes(if_name, io_counters, if_stats):
 
     if if_name in if_stats:
         if if_stats[if_name].isup:
-            status = "up"
             numeric_status = 0
         else:
-            status = "down"
             numeric_status = 2
     else:
-        status = "unknown"
         numeric_status = 3
-    statusNode = RunnableNode("status", method=lambda: (numeric_status, status))
+    statusNode = RunnableNode("status", method=lambda: (numeric_status, ""))
 
     return RunnableParentNode(
         if_name,

--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -441,7 +441,10 @@ def get_interface_node():
         make_if_nodes(if_name, io_counters, if_stats) for if_name in io_counters.keys()
     ]
 
-    logging.debug("Child data for interfaces: %s", if_children)
+    # log if_children in a more readable format
+    for child in if_children:
+        logging.debug("Interface: %s, Children: %s", child.name, [c.name for c in child.children])
+
     return ParentNode("interface", children=if_children)
 
 

--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -230,9 +230,9 @@ def make_if_nodes(if_name, io_counters, if_stats):
 
     if if_name in if_stats:
         if if_stats[if_name].isup:
-            status = "up"
+            status = 1
         else:
-            status = "down"
+            status = 0
     else:
         status = "unknown"
     statusNode = RunnableNode("status", method=lambda: (status, ""))
@@ -440,11 +440,6 @@ def get_interface_node():
     if_children = [
         make_if_nodes(if_name, io_counters, if_stats) for if_name in io_counters.keys()
     ]
-
-    # log if_children in a more readable format
-    for child in if_children:
-        logging.debug("Interface: %s, Children: %s", child.name, [c.name for c in child.children])
-
     return ParentNode("interface", children=if_children)
 
 


### PR DESCRIPTION
This changes the improper string returned in the perfdata to a proper exit code that can be monitored, graphed, and alerted on now. 

I also updated the RunnableNode get_nagios_return() method to change the exit codes for `status` queries into human readable text like up or down so that the Nagios Status Information makes sense.

<img width="944" height="116" alt="Screenshot 2026-03-24 112539" src="https://github.com/user-attachments/assets/5024dea2-10a9-43eb-9c61-9586bc9c76af" />

Closes #1371 