### PR TITLE
Upgrade AIX python cryptography to latest version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
 
 **Updates**
 
-- Upgraded AIX Python Cryptography package to use IBM Toolbox compiled version 44.0.2 to resolve CVEs and improve compatibility. [GH#1355] - CPD
+- Upgraded AIX Python cryptography package to use IBM Toolbox compiled version 44.0.2 to resolve CVEs and improve compatibility. [GH#1355] - CPD
 - Removed redundant Python executable from the install to reduce potential attack surface and confusion. - CPD
 
 3.3.1 - 3/19/2026

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
 
 **Updates**
 
-- Upgraded AIX Python cryptography package to use IBM Toolbox compiled version 44.0.2 to resolve CVEs and improve compatibility. [GH#1355] - CPD
+- Removed version pin for AIX Python cryptography to allow updates to the latest stable release. [GH#1355] - CPD
 - Removed redundant Python executable from the install to reduce potential attack surface and confusion. - CPD
 
 3.3.1 - 3/19/2026

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 
 **Updates**
 
+- Upgraded AIX Python Cryptography package to use IBM Toolbox compiled version 44.0.2 to resolve CVEs and improve compatibility. [GH#1355] - CPD
 - Removed redundant Python executable from the install to reduce potential attack surface and confusion. - CPD
 
 3.3.1 - 3/19/2026

--- a/build/aix/setup.sh
+++ b/build/aix/setup.sh
@@ -7,6 +7,10 @@
 VENV_MANAGER="${BUILD_DIR}/venv_manager.sh"
 VENV_NAME="${VENV_NAME:-ncpa-build}"
 
+# Export necessary build environment variables
+export MAKE="gmake"
+export CC="gcc"
+
 # Check if using virtual environment or fallback to system Python
 if [[ "$SKIP_PYTHON" == "1" ]]; then
     echo "***** aix/setup.sh - Using virtual environment mode"
@@ -169,11 +173,6 @@ build_patchelf() {
             echo "patchelf source directory found."
         fi
     fi
-
-    # Export necessary build environment variables
-    export MAKE="gmake"
-    export CC="gcc"
-    export PKG_CONFIG_PATH=/usr/lib/pkgconfig:$PKG_CONFIG_PATH
 
     # Change to patchelf source directory
     echo "Changing to patchelf source directory..."

--- a/build/aix/setup.sh
+++ b/build/aix/setup.sh
@@ -34,7 +34,7 @@ install_prereqs() {
     
     echo "    - Installing required build packages via dnf..."
     dnf -y update
-    dnf -y install sudo gcc gcc-c++ gcc-cpp make cmake automake libffi-devel
+    dnf -y install sudo gcc gcc-c++ gcc-cpp make cmake automake libffi-devel rust cargo
 
     # Ensure Python 3.12 is installed
     if command -v python3.12 >/dev/null 2>&1; then
@@ -45,7 +45,7 @@ install_prereqs() {
     fi
 
     echo "    - Assuming Python 3.12 is the target version for NCPA build"
-    dnf -y install python3.12-pip python3.12-devel 
+    dnf -y install python3.12-pip python3.12-devel
 
     echo "----------------------------------------"
     echo "Adding additional tools from source..."
@@ -172,6 +172,7 @@ build_patchelf() {
 
     # Export necessary build environment variables
     export MAKE="gmake"
+    export CC="gcc"
 
     # Change to patchelf source directory
     echo "Changing to patchelf source directory..."

--- a/build/aix/setup.sh
+++ b/build/aix/setup.sh
@@ -7,10 +7,6 @@
 VENV_MANAGER="${BUILD_DIR}/venv_manager.sh"
 VENV_NAME="${VENV_NAME:-ncpa-build}"
 
-# Export necessary build environment variables
-export MAKE="gmake"
-export CC="gcc"
-
 # Check if using virtual environment or fallback to system Python
 if [[ "$SKIP_PYTHON" == "1" ]]; then
     echo "***** aix/setup.sh - Using virtual environment mode"
@@ -174,6 +170,9 @@ build_patchelf() {
         fi
     fi
 
+    # Export necessary build environment variables
+    export MAKE="gmake"
+
     # Change to patchelf source directory
     echo "Changing to patchelf source directory..."
     cd patchelf-0.18.0
@@ -211,6 +210,8 @@ set +e
 mkgroup nagios
 mkuser pgrp='nagios' groups='nagios' home='/home/nagios' nagios
 set -e
+
+export CC="gcc"
 
 # Automatically install Python requirements in venv after setup
 echo "***** aix/setup.sh - Installing Python requirements in virtual environment if applicable"

--- a/build/aix/setup.sh
+++ b/build/aix/setup.sh
@@ -45,7 +45,7 @@ install_prereqs() {
     fi
 
     echo "    - Assuming Python 3.12 is the target version for NCPA build"
-    dnf -y install python3.12-pip python3.12-devel python3.12-cryptography
+    dnf -y install python3.12-pip python3.12-devel
 
     echo "----------------------------------------"
     echo "Adding additional tools from source..."

--- a/build/aix/setup.sh
+++ b/build/aix/setup.sh
@@ -45,7 +45,7 @@ install_prereqs() {
     fi
 
     echo "    - Assuming Python 3.12 is the target version for NCPA build"
-    dnf -y install python3.12-pip python3.12-devel
+    dnf -y install python3.12-pip python3.12-devel 
 
     echo "----------------------------------------"
     echo "Adding additional tools from source..."

--- a/build/aix/setup.sh
+++ b/build/aix/setup.sh
@@ -211,6 +211,7 @@ mkgroup nagios
 mkuser pgrp='nagios' groups='nagios' home='/home/nagios' nagios
 set -e
 
+# Setup the c compiler export for building python cryptography after prerequisites are installed
 export CC="gcc"
 
 # Automatically install Python requirements in venv after setup

--- a/build/aix/setup.sh
+++ b/build/aix/setup.sh
@@ -173,6 +173,7 @@ build_patchelf() {
     # Export necessary build environment variables
     export MAKE="gmake"
     export CC="gcc"
+    export PKG_CONFIG_PATH=/usr/lib/pkgconfig:$PKG_CONFIG_PATH
 
     # Change to patchelf source directory
     echo "Changing to patchelf source directory..."

--- a/build/aix/setup.sh
+++ b/build/aix/setup.sh
@@ -45,7 +45,7 @@ install_prereqs() {
     fi
 
     echo "    - Assuming Python 3.12 is the target version for NCPA build"
-    dnf -y install python3.12-pip python3.12-devel 
+    dnf -y install python3.12-pip python3.12-devel python3.12-cryptography
 
     echo "----------------------------------------"
     echo "Adding additional tools from source..."

--- a/build/resources/require-aix.txt
+++ b/build/resources/require-aix.txt
@@ -5,7 +5,7 @@ flask
 werkzeug
 docutils
 pyOpenSSL
-cryptography==1.8.1
+cryptography==44.0.2
 gevent
 gevent-websocket
 cffi

--- a/build/resources/require-aix.txt
+++ b/build/resources/require-aix.txt
@@ -5,7 +5,7 @@ flask
 werkzeug
 docutils
 pyOpenSSL
-cryptography==44.0.2
+cryptography
 gevent
 gevent-websocket
 cffi

--- a/build/resources/require-aix.txt
+++ b/build/resources/require-aix.txt
@@ -1,4 +1,4 @@
-psutil==7.0.0
+psutil
 requests
 Jinja2
 flask

--- a/build/resources/require-aix.txt
+++ b/build/resources/require-aix.txt
@@ -1,4 +1,4 @@
-psutil
+psutil==7.0.0
 requests
 Jinja2
 flask

--- a/build/venv_manager.sh
+++ b/build/venv_manager.sh
@@ -387,6 +387,7 @@ create_venv() {
             error "Failed to create virtual environment"
             return 1
         fi
+    fi
     
     # Verify venv creation
     if [ ! -f "$VENV_PATH/bin/activate" ] && [ ! -f "$VENV_PATH/Scripts/activate" ]; then

--- a/build/venv_manager.sh
+++ b/build/venv_manager.sh
@@ -367,7 +367,7 @@ create_venv() {
     if [ "$PLATFORM" = "aix" ]; then
         if command -v dnf >/dev/null 2>&1; then
             log "Using dnf to install python3.12-venv for AIX virtual environment support..."
-            sudo dnf install -y python3.12-cryptography || {
+            dnf install -y python3.12-cryptography || {
                 error "Failed to install python3.12-cryptography on AIX. Please ensure it's available in your repositories."
                 return 1
             }

--- a/build/venv_manager.sh
+++ b/build/venv_manager.sh
@@ -361,32 +361,11 @@ create_venv() {
     mkdir -p "$VENV_BASE_DIR"
     
     # Create the virtual environment
-    #
-    # AIX uses the IBM compiled Python cryptography package, while other platforms can use pip for all Python modules, 
-    # so we need to handle venv creation differently for AIX
-    if [ "$PLATFORM" = "aix" ]; then
-        if command -v dnf >/dev/null 2>&1; then
-            log "Using dnf to install AIX python cryptography support..."
-            dnf install -y python3.12-cryptography || {
-                error "Failed to install python3.12-cryptography on AIX. Please ensure it's available in your repositories."
-                return 1
-            }
-        else
-            error "dnf package manager not found on AIX. Please install python3.12-cryptography manually."
-            return 1
-        fi
-        log "Using system Python venv module for AIX (python3.12-venv) to create virtual environment..."
-        if ! "$PYTHON_EXECUTABLE" -m venv --system-site-packages "$VENV_PATH"; then
-            error "Failed to create virtual environment with system venv module on AIX"
-            return 1
-        fi
-    else
-        # Standard venv creation for other platforms
-        log "Creating virtual environment with Python $PYTHON_VERSION..."
-        if ! "$PYTHON_EXECUTABLE" -m venv "$VENV_PATH"; then
-            error "Failed to create virtual environment"
-            return 1
-        fi
+    # Standard venv creation for other platforms
+    log "Creating virtual environment with Python $PYTHON_VERSION..."
+    if ! "$PYTHON_EXECUTABLE" -m venv "$VENV_PATH"; then
+        error "Failed to create virtual environment"
+        return 1
     fi
     
     # Verify venv creation

--- a/build/venv_manager.sh
+++ b/build/venv_manager.sh
@@ -361,7 +361,6 @@ create_venv() {
     mkdir -p "$VENV_BASE_DIR"
     
     # Create the virtual environment
-    # Standard venv creation for other platforms
     log "Creating virtual environment with Python $PYTHON_VERSION..."
     if ! "$PYTHON_EXECUTABLE" -m venv "$VENV_PATH"; then
         error "Failed to create virtual environment"

--- a/build/venv_manager.sh
+++ b/build/venv_manager.sh
@@ -366,7 +366,7 @@ create_venv() {
     # so we need to handle venv creation differently for AIX
     if [ "$PLATFORM" = "aix" ]; then
         if command -v dnf >/dev/null 2>&1; then
-            log "Using dnf to install python3.12-venv for AIX virtual environment support..."
+            log "Using dnf to install AIX python cryptography support..."
             dnf install -y python3.12-cryptography || {
                 error "Failed to install python3.12-cryptography on AIX. Please ensure it's available in your repositories."
                 return 1

--- a/build/venv_manager.sh
+++ b/build/venv_manager.sh
@@ -361,11 +361,32 @@ create_venv() {
     mkdir -p "$VENV_BASE_DIR"
     
     # Create the virtual environment
-    log "Creating virtual environment with Python $PYTHON_VERSION..."
-    if ! "$PYTHON_EXECUTABLE" -m venv "$VENV_PATH"; then
-        error "Failed to create virtual environment"
-        return 1
-    fi
+    #
+    # AIX uses the IBM compiled Python cryptography package, while other platforms can use pip for all Python modules, 
+    # so we need to handle venv creation differently for AIX
+    if [ "$PLATFORM" = "aix" ]; then
+        if command -v dnf >/dev/null 2>&1; then
+            log "Using dnf to install python3.12-venv for AIX virtual environment support..."
+            sudo dnf install -y python3.12-cryptography || {
+                error "Failed to install python3.12-cryptography on AIX. Please ensure it's available in your repositories."
+                return 1
+            }
+        else
+            error "dnf package manager not found on AIX. Please install python3.12-cryptography manually."
+            return 1
+        fi
+        log "Using system Python venv module for AIX (python3.12-venv) to create virtual environment..."
+        if ! "$PYTHON_EXECUTABLE" -m venv --system-site-packages "$VENV_PATH"; then
+            error "Failed to create virtual environment with system venv module on AIX"
+            return 1
+        fi
+    else
+        # Standard venv creation for other platforms
+        log "Creating virtual environment with Python $PYTHON_VERSION..."
+        if ! "$PYTHON_EXECUTABLE" -m venv "$VENV_PATH"; then
+            error "Failed to create virtual environment"
+            return 1
+        fi
     
     # Verify venv creation
     if [ ! -f "$VENV_PATH/bin/activate" ] && [ ! -f "$VENV_PATH/Scripts/activate" ]; then


### PR DESCRIPTION
I was able to resolve the rust build issues on AIX compiling the latest version of python cryptography. 

I have removed the version pin so we should be able to install the latest releases of cryptography like the other builds from this point forward.

Closes #1355