### PR TITLE
Update Windows bundled Python to version 3.13.13 and OpenSSL to 3.0.19

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Changelog
 
 **Updates**
 
+- Updated Windows builds to use Python version 3.13.13. - CPD
+- Updated Windows builds to use OpenSSL version to 3.0.19 to resolve CVEs and improve compatibility. [GH#1359] - CPD
 - Removed version pin for AIX Python cryptography to allow updates to the latest stable release. [GH#1355] - CPD
 - Removed redundant Python executable from the install to reduce potential attack surface and confusion. - CPD
 - Updated the build documentation with more detailed requirements for building on Linux systems. - CPD

--- a/build/windows/choco_prereqs.ps1
+++ b/build/windows/choco_prereqs.ps1
@@ -51,7 +51,7 @@ if(-not (Get-Command nasm   -ErrorAction SilentlyContinue)){ choco install nasm 
 if(-not (Get-Command nsis   -ErrorAction SilentlyContinue)){ choco install nsis -y }
 
 # Use environment variable or default Python version
-$pythonVersion = if ($env:WINDOWS_PYTHONVER) { $env:WINDOWS_PYTHONVER } else { "3.13.12" }
+$pythonVersion = if ($env:WINDOWS_PYTHONVER) { $env:WINDOWS_PYTHONVER } else { "3.13.13" }
 choco install python --version=$pythonVersion -y --force
 #choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools;includeRecommended" -y
 choco install visualstudio2022buildtools -y --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.Windows10SDK.18362"


### PR DESCRIPTION
These changes update the Windows builds to use the latest available versions of Python and OpenSSL.

Closes #1359 