### PR TITLE
Removed some old debug log lines to help cleanup the logs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Changelog
 - Fixed multiple issues on the admin passive checks page of the GUI that were causing some checks to not display properly. [GH#1238] - CPD
 - Fixed multiple issues with the add passive check function in the API that were causing errors when trying to add checks with certain parameters. - CPD
 
+**Removed**
+
+- Removed some old debug log lines to help declutter the log files when debug logging is enabled. - CPD
+
 3.4.0 - 4/23/2026
 ==================
 **Added**

--- a/agent/listener/server.py
+++ b/agent/listener/server.py
@@ -191,7 +191,6 @@ def before_request():
     # allowed is set to False by default
     allowed = False
     allowed_hosts = get_config_value('listener', 'allowed_hosts')
-    listener_logger.debug("    before_request() - type(request.view_args): %s", type(request.view_args))
 
     # For logging some debug info for actual page requests
     if isinstance(request.view_args, dict) and ('filename' not in request.view_args):
@@ -204,10 +203,6 @@ def before_request():
             new_parts.append('&'.join(sub_parts))
         logurl = 'token='.join(new_parts)
         listener_logger.info("before_request() - request.url: %s", logurl)
-        listener_logger.debug("    before_request() - request.path: %s", request.path)
-        listener_logger.debug("    before_request() - request.url_rule: %s", request.url_rule)
-        listener_logger.debug("    before_request() - request.view_args: %s", request.view_args)
-        listener_logger.debug("    before_request() - request.routing_exception: %s", request.routing_exception)
 
     if allowed_hosts and __INTERNAL__ is False:
         if request.remote_addr:


### PR DESCRIPTION
We can always add these back if we ever need to debug these values again.

I left the info log line in before_requests() since it seems like it could still be helpful in certain situations.