### PR TITLE
ncpa.py: use config-file and config-dir args

### DIFF
--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -1181,7 +1181,7 @@ def get_configuration(config=None, configdir=None):
 
     if config is None:
         config = os.path.join('etc', 'ncpa.cfg')
-    if configDir is None:
+    if configdir is None:
         configdir = os.path.join('etc', 'ncpa.cfg.d', '*.cfg')
 
     cp = ConfigParser(interpolation=None)

--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -1179,8 +1179,10 @@ def get_configuration(config=None, configdir=None):
     """Get the configuration options and return the config parser for them"""
     parent_logger.debug("get_configuration()")
 
-    config = os.path.join('etc', 'ncpa.cfg')
-    configdir = os.path.join('etc', 'ncpa.cfg.d', '*.cfg')
+    if config is None:
+        config = os.path.join('etc', 'ncpa.cfg')
+    if configDir is None:
+        configdir = os.path.join('etc', 'ncpa.cfg.d', '*.cfg')
 
     cp = ConfigParser(interpolation=None)
     cp.optionxform = str


### PR DESCRIPTION
The `get_configuration()` function accepts these as arguments, but they were not used. This change allows the `--config-file` and `--config-dir` args to be used.