### PR TITLE
Prevent insecure request warnings from appearing in system logs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 ==================
 **Bug Fixes**
 
-- Fixed an issue where the config-file and config-dir options were not working properly, causing NCPA to not read the config file(s) from the specified location(s). - coonce 
+- Fixed an issue where the config-file and config-dir options were not working properly, causing NCPA to not read the config file(s) from the specified location(s). - coonce
+- Fixed an issue where warnings were being logged in the system logs in addition to the ncpa_passive.log when SSL verification failed. [GH#1050] - CPD
 
 3.4.1 - 5/21/2026
 ==================

--- a/agent/passive/utils.py
+++ b/agent/passive/utils.py
@@ -2,6 +2,10 @@ import requests
 import requests.exceptions
 from ncpa import passive_logger as logging
 
+# Disable InsecureRequestWarning globally since we handle SSL verification in our send_request function 
+# and want to avoid cluttering logs with warnings when SSL verification fails and we retry without it.
+# Note: these messages will still be logged in ncpa_passive.log, but they should not go to /var/log/messages
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 def send_request(url, connection_timeout, **kwargs):
     """

--- a/agent/passive/utils.py
+++ b/agent/passive/utils.py
@@ -1,5 +1,6 @@
 import requests
 import requests.exceptions
+import urllib3.exceptions
 from ncpa import passive_logger as logging
 
 # Disable InsecureRequestWarning globally since we handle SSL verification in our send_request function 


### PR DESCRIPTION
The warning messages still appear in the ncpa_passive.log but should no longer show up in /var/log/messages or /var/log/syslog.

Related: #1050 