### PR TITLE
Cleanup old Windows python binary files in the NCPA install directory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changelog
 
 - Fixed an issue where the config-file and config-dir options were not working properly, causing NCPA to not read the config file(s) from the specified location(s). - coonce
 - Fixed an issue where warnings were being logged in the system logs in addition to the ncpa_passive.log when SSL verification failed. [GH#1050] - CPD
-- Fixed an issue where old Windows python binary files were not being removed during upgrades. - CPD
+- Fixed an issue where old Windows python binary files in the NCPA install directory were not being removed during upgrades. - CPD
 
 **Updates**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 - Fixed an issue where the config-file and config-dir options were not working properly, causing NCPA to not read the config file(s) from the specified location(s). - coonce
 - Fixed an issue where warnings were being logged in the system logs in addition to the ncpa_passive.log when SSL verification failed. [GH#1050] - CPD
+- Fixed an issue where old Windows python binary files were not being removed during upgrades. - CPD
 
 **Updates**
 

--- a/build/resources/ncpa.nsi
+++ b/build/resources/ncpa.nsi
@@ -350,6 +350,7 @@ Section # "Create Config.ini"
     RMDir /r "$INSTDIR\lib"
     RMDir /r "$INSTDIR\listener"
     Delete "$INSTDIR\python*.dll"
+    Delete "$INSTDIR\python*.exe"
 
     SetOutPath $INSTDIR
 


### PR DESCRIPTION
As of NCPA 3.4.0 the extra python.exe is no longer included in installations since python is already contained in the ncpa.exe binary.

This change will remove the old python.exe when upgrading from NCPA <= 3.3.1 which did include the python.exe file.