### PR TITLE
Update windows python to 3.13.14 and OpenSSL to 3.0.21

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Changelog
 
 - Placeholder for future release updates. - CPD
 
+**Updates**
+
+- Updated Windows builds to use Python version 3.13.14. - CPD
+- Updated Windows builds to use OpenSSL version 3.0.21 to resolve CVEs and improve compatibility. [GH#1397] - CPD
+
 3.4.2 - 6/18/2026
 ==================
 **Added**

--- a/build/windows/choco_prereqs.ps1
+++ b/build/windows/choco_prereqs.ps1
@@ -51,7 +51,7 @@ if(-not (Get-Command nasm   -ErrorAction SilentlyContinue)){ choco install nasm 
 if(-not (Get-Command nsis   -ErrorAction SilentlyContinue)){ choco install nsis -y }
 
 # Use environment variable or default Python version
-$pythonVersion = if ($env:WINDOWS_PYTHONVER) { $env:WINDOWS_PYTHONVER } else { "3.13.13" }
+$pythonVersion = if ($env:WINDOWS_PYTHONVER) { $env:WINDOWS_PYTHONVER } else { "3.13.14" }
 choco install python --version=$pythonVersion -y --force
 #choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools;includeRecommended" -y
 choco install visualstudio2022buildtools -y --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.Windows10SDK.18362"


### PR DESCRIPTION
This updates the versions of Python and OpenSSL to the latest available for Windows builds.

Closes #1397 