### PR TITLE
Fix rpm -V false positives on RHEL packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 - Fixed an issue where the total count and pagination numbers in the Checks UI were incorrect when filtered by Type. - CPD
 - Fixed multiple AIX build issue with dependencies that were preventing the build from completing successfully. - CPD
 - Fixed multiple AIX upgrade issues that were preventing upgrades from NCPA 2.x to NCPA 3.x from completing successfully. - CPD
+- Fixed rpm -V reporting false positives on RHEL for config, log, database, and service files. [GH#1299] - CPD
 
 **Removed**
 

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -45,11 +45,9 @@ mkdir -p %{buildroot}/etc/init.d
 touch %{buildroot}/usr/local/ncpa/var/ncpa.db
 chown nagios:nagios %{buildroot}/usr/local/ncpa -R
 install -m 755 $RPM_BUILD_DIR/ncpa-%{version}/build_resources/default-init %{buildroot}/etc/init.d/ncpa
-sed -i 's|_BASEDIR_|BASEDIR="%{_prefix}/ncpa"|' %{buildroot}/etc/init.d/ncpa
 
 mkdir -p %{buildroot}/usr/lib/systemd/system
 install -m 640 $RPM_BUILD_DIR/ncpa-%{version}/build_resources/default-service %{buildroot}/usr/lib/systemd/system/ncpa.service
-sed -i 's|_BASEDIR_|%{_prefix}/ncpa|' %{buildroot}/usr/lib/systemd/system/ncpa.service
 
 %clean
 rm -rf %{buildroot}
@@ -132,6 +130,11 @@ if [ -z $RPM_INSTALL_PREFIX ]
 then
     RPM_INSTALL_PREFIX="/usr/local"
 fi
+
+# Set the directory inside the init scripts
+dir=$RPM_INSTALL_PREFIX/ncpa
+sed -i "s|_BASEDIR_|BASEDIR=\x22$dir\x22|" /etc/init.d/ncpa
+sed -i "s|_BASEDIR_|$dir|" /usr/lib/systemd/system/ncpa.service
 
 if command -v systemctl &> /dev/null; then
     systemctl enable ncpa &> /dev/null

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -49,6 +49,11 @@ install -m 755 $RPM_BUILD_DIR/ncpa-%{version}/build_resources/default-init %{bui
 mkdir -p %{buildroot}/usr/lib/systemd/system
 install -m 640 $RPM_BUILD_DIR/ncpa-%{version}/build_resources/default-service %{buildroot}/usr/lib/systemd/system/ncpa.service
 
+# Set the directory inside the init scripts
+dir=$RPM_INSTALL_PREFIX/ncpa
+sed -i "s|_BASEDIR_|BASEDIR=\x22$dir\x22|" /etc/init.d/ncpa
+sed -i "s|_BASEDIR_|$dir|" /usr/lib/systemd/system/ncpa.service
+
 %clean
 rm -rf %{buildroot}
 
@@ -130,11 +135,6 @@ if [ -z $RPM_INSTALL_PREFIX ]
 then
     RPM_INSTALL_PREFIX="/usr/local"
 fi
-
-# Set the directory inside the init scripts
-dir=$RPM_INSTALL_PREFIX/ncpa
-sed -i "s|_BASEDIR_|BASEDIR=\x22$dir\x22|" /etc/init.d/ncpa
-sed -i "s|_BASEDIR_|$dir|" /usr/lib/systemd/system/ncpa.service
 
 if command -v systemctl &> /dev/null; then
     systemctl enable ncpa &> /dev/null

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -45,9 +45,11 @@ mkdir -p %{buildroot}/etc/init.d
 touch %{buildroot}/usr/local/ncpa/var/ncpa.db
 chown nagios:nagios %{buildroot}/usr/local/ncpa -R
 install -m 755 $RPM_BUILD_DIR/ncpa-%{version}/build_resources/default-init %{buildroot}/etc/init.d/ncpa
+sed -i 's|_BASEDIR_|BASEDIR="%{_prefix}/ncpa"|' %{buildroot}/etc/init.d/ncpa
 
 mkdir -p %{buildroot}/usr/lib/systemd/system
 install -m 640 $RPM_BUILD_DIR/ncpa-%{version}/build_resources/default-service %{buildroot}/usr/lib/systemd/system/ncpa.service
+sed -i 's|_BASEDIR_|%{_prefix}/ncpa|' %{buildroot}/usr/lib/systemd/system/ncpa.service
 
 %clean
 rm -rf %{buildroot}
@@ -130,12 +132,6 @@ if [ -z $RPM_INSTALL_PREFIX ]
 then
     RPM_INSTALL_PREFIX="/usr/local"
 fi
-
-# Set the directory inside the init scripts
-dir=$RPM_INSTALL_PREFIX/ncpa
-sed -i "s|_BASEDIR_|BASEDIR=\x22$dir\x22|" /etc/init.d/ncpa
-sed -i "s|_BASEDIR_|$dir|" /usr/lib/systemd/system/ncpa.service
-
 
 if command -v systemctl &> /dev/null; then
     systemctl enable ncpa &> /dev/null
@@ -275,10 +271,15 @@ fi
 %defattr(0664,root,nagios,0775)
 %dir /usr/local/ncpa/etc
 %dir /usr/local/ncpa/etc/ncpa.cfg.d
-/usr/local/ncpa/var
+%dir /usr/local/ncpa/var
+%dir /usr/local/ncpa/var/log
+%dir /usr/local/ncpa/var/run
+%verify(not md5 size mtime mode user group) /usr/local/ncpa/var/log/ncpa_listener.log
+%verify(not md5 size mtime mode user group) /usr/local/ncpa/var/log/ncpa_passive.log
+%verify(not md5 size mtime) /usr/local/ncpa/var/ncpa.db
 
 %defattr(0640,root,nagios,0755)
-%config(noreplace) /usr/local/ncpa/etc/ncpa.cfg
+%config(noreplace) %verify(not md5 size mtime mode) /usr/local/ncpa/etc/ncpa.cfg
 %config(noreplace) /usr/local/ncpa/etc/ncpa.cfg.d/example.cfg
 /usr/local/ncpa/etc/ncpa.cfg.sample
 /usr/local/ncpa/etc/ncpa.cfg.d/README.txt

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -45,14 +45,11 @@ mkdir -p %{buildroot}/etc/init.d
 touch %{buildroot}/usr/local/ncpa/var/ncpa.db
 chown nagios:nagios %{buildroot}/usr/local/ncpa -R
 install -m 755 $RPM_BUILD_DIR/ncpa-%{version}/build_resources/default-init %{buildroot}/etc/init.d/ncpa
+sed -i 's|_BASEDIR_|BASEDIR="/usr/local/ncpa"|' %{buildroot}/etc/init.d/ncpa
 
 mkdir -p %{buildroot}/usr/lib/systemd/system
 install -m 640 $RPM_BUILD_DIR/ncpa-%{version}/build_resources/default-service %{buildroot}/usr/lib/systemd/system/ncpa.service
-
-# Set the directory inside the init scripts
-dir=$RPM_INSTALL_PREFIX/ncpa
-sed -i "s|_BASEDIR_|BASEDIR=\x22$dir\x22|" /etc/init.d/ncpa
-sed -i "s|_BASEDIR_|$dir|" /usr/lib/systemd/system/ncpa.service
+sed -i 's|_BASEDIR_|/usr/local/ncpa|' %{buildroot}/usr/lib/systemd/system/ncpa.service
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
### Summary
On RHEL 8, `rpm -V` ncpa was reporting changes to files that are expected to differ during normal operation or installation, causing unnecessary audit findings.

This PR addresses that in two ways:

- Runtime/mutable files — Added %verify(not …) directives in the %files section for files that legitimately change after install:
  - /usr/local/ncpa/etc/ncpa.cfg (config edits)
  - /usr/local/ncpa/var/log/ncpa_listener.log and ncpa_passive.log (runtime logs)
  - /usr/local/ncpa/var/ncpa.db (SQLite database)

- Init/systemd service files — Moved the _BASEDIR_ sed substitution from %post to %install in build/linux/ncpa.spec, so /etc/init.d/ncpa and /usr/lib/systemd/system/ncpa.service are written with the correct install path at package build time instead of being modified post-install.

Also replaced the blanket /usr/local/ncpa/var entry with explicit %dir and file listings so verify rules apply cleanly.

### Test plan
- [x]  Build the RPM on RHEL 8
- [x]  Install the package on a clean RHEL 8 system
- [x]  Run rpm -V ncpa — should return no output (exit 0)
- [x]  Confirm NCPA starts and runs normally (systemctl status ncpa)
- [x]  Modify ncpa.cfg, write to log files, and let the DB update — re-run rpm -V ncpa and confirm no new flags
- [x]  Verify /etc/init.d/ncpa and /usr/lib/systemd/system/ncpa.service contain the correct /usr/local/ncpa paths

Fixes #1299