### PR TITLE
fix(build): fixes non CentOS el 10 builds 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,14 @@ Changelog
 +++++++++
 3.4.3 - 7/23/2026
 ==================
+
 **Bug Fixes**
 
 - Fixed an AIX upgrade issue that was preventing the NCPA service from starting automatically after an upgrade. - CPD
 - Fixed an issue where the total count and pagination numbers in the Checks UI were incorrect when filtered by Type. - CPD
 - Fixed multiple AIX build issue with dependencies that were preventing the build from completing successfully. - CPD
 - Fixed multiple AIX upgrade issues that were preventing upgrades from NCPA 2.x to NCPA 3.x from completing successfully. - CPD
+- Fixed an issue where builds would fail on el 10 systems due to a missing dependency. - BB
 
 **Removed**
 

--- a/build/linux/setup.sh
+++ b/build/linux/setup.sh
@@ -104,12 +104,17 @@ install_prereqs() {
         else
             if [ "$distro" == "CentOS" ]; then
                 yum -y install epel-release
-                
-                # Enable CRB (CodeReady Builder) repository for development packages
-                # This provides gdbm-devel and other development libraries
-                if command -v dnf >/dev/null 2>&1; then
-                    echo -e "***** linux/setup.sh - enabling CRB repository for development packages"
-                    dnf config-manager --enable crb 2>/dev/null || true
+            fi
+
+            # Enable CRB (CodeReady Builder) repository for development packages
+            # This provides gdbm-devel and other development libraries
+            if command -v dnf >/dev/null 2>&1; then
+                echo -e "***** linux/setup.sh - enabling CRB repository for development packages"
+                crb_repo=$(dnf repolist all 2>/dev/null | grep -i 'codeready-builder' | grep -i rpms | grep -v -E 'debug|source|eus' | awk '{print $1}' | head -1)
+                if [ -n "$crb_repo" ]; then
+                    dnf config-manager --set-enabled "$crb_repo" 2>/dev/null || true
+                else
+                    dnf config-manager --set-enabled crb 2>/dev/null || true
                 fi
             fi
         fi


### PR DESCRIPTION
I tried building on RHEL 10 and it didn't work because we were missing CRB. This fixes that. Tested on RHEL 10, CentOS 10 and Oracle 10.