### PR TITLE
fix: prevent NameError when set_process_name runs after stop

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 - Fixed multiple AIX build issue with dependencies that were preventing the build from completing successfully. - CPD
 - Fixed multiple AIX upgrade issues that were preventing upgrades from NCPA 2.x to NCPA 3.x from completing successfully. - CPD
 - Fixed rpm -V reporting false positives on RHEL for config, log, database, and service files. [GH#1299] - CPD
+- Fixed an issue that could occur if the process attempted to rename itself during a passive listener shutdown sequence. - CPD
 
 **Removed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,11 +5,11 @@ Changelog
 **Bug Fixes**
 
 - Fixed an AIX upgrade issue that was preventing the NCPA service from starting automatically after an upgrade. - CPD
+- Fixed an error message that can appear in /var/log/messages on Linux systems when the NCPA service is stopped. - CPD
 - Fixed an issue where the total count and pagination numbers in the Checks UI were incorrect when filtered by Type. - CPD
 - Fixed multiple AIX build issue with dependencies that were preventing the build from completing successfully. - CPD
 - Fixed multiple AIX upgrade issues that were preventing upgrades from NCPA 2.x to NCPA 3.x from completing successfully. - CPD
 - Fixed rpm -V reporting false positives on RHEL for config, log, database, and service files. [GH#1299] - CPD
-- Fixed an issue that could occur if the process attempted to rename itself during a passive listener shutdown sequence. - CPD
 
 **Removed**
 

--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -243,8 +243,10 @@ class Listener(Base):
     to run the listener so all of NCPA is bundled in a single service
     """
     def __init__(self, options, config, has_error, autostart=False):
-        super().__init__(options, config, has_error, autostart)
-        set_process_name("Nagios Cross-Platform Agent - Listener")
+        super().__init__(options, config, has_error, False)
+        self.set_process_name("Nagios Cross-Platform Agent - Listener")
+        if autostart:
+            self.run()
 
     def run(self):
         self.init_logger('listener')
@@ -362,8 +364,10 @@ class Passive(Base):
     separate thread since it is what the main process is used for
     """
     def __init__(self, options, config, has_error, autostart=False):
-        super().__init__(options, config, has_error, autostart)
-        set_process_name("Nagios Cross-Platform Agent - Passive")
+        super().__init__(options, config, has_error, False)
+        self.set_process_name("Nagios Cross-Platform Agent - Passive")
+        if autostart:
+            self.run()
 
     def run_all_handlers(self, *args, **kwargs):
         """


### PR DESCRIPTION
### Summary
Fixes a NameError that appeared in /var/log/messages when stopping or uninstalling NCPA on Linux.

Listener and Passive child processes called set_process_name(...) as a bare function, but it is an instance method on Base (self.set_process_name). Because Base.__init__ starts the main loop immediately when autostart=True, that call was deferred until run() returned — which only happens on shutdown (e.g. systemctl stop ncpa or RPM/DEB uninstall). At that point the child crashed with:

NameError: name 'set_process_name' is not defined. Did you mean: 'self.set_process_name'?

This change:

- Calls self.set_process_name(...) correctly in both Listener and Passive
- Sets the process name before starting run(), so naming works at startup and shutdown no longer triggers the error

### Test plan
- [x]  Start NCPA on Linux (systemctl start ncpa or ncpa -n)
- [x]  Confirm listener and passive child processes start normally and NCPA responds to API checks
- [x]  Stop the service (systemctl stop ncpa or ncpa --stop)
- [x]  Verify /var/log/messages (and journalctl -u ncpa) contain no NameError for set_process_name
- [x]  Uninstall the package (rpm -e / apt remove) while the service was previously running
- [x]  Confirm uninstall completes cleanly with no set_process_name traceback in system logs
- [x]  Repeat stop/uninstall on a system with legacy ncpa_listener / ncpa_passive services if applicable