### PR TITLE
#1306 | fix: skip privilege drop and root-only startup tasks when not running as root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Changelog
 - Fixed an issue where builds would fail on el 10 systems due to a missing dependency. - BB
 - Fixed rpm -V reporting false positives on RHEL for config, log, database, and service files. [GH#1299] - CPD
 - Fixed an issue where NCPA would fail to start when started without root privileges after the configured uid/gid had already been applied. [GH#1306] - CPD
-- Fixed root-only startup tasks (log file chown, temp file cleanup, directory creation) running when NCPA was not started as root, which could cause startup failures on non-root deployments. [GH#1306] - CPD
+- Fixed root-only startup tasks (log file chown, temp file cleanup, directory creation) which could cause startup failures on non-root deployments. [GH#1306] - CPD
 - Several improvements to disk endpoint performance. [GH#1282] - BB
 
 **Removed**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Changelog
 - Fixed multiple AIX upgrade issues that were preventing upgrades from NCPA 2.x to NCPA 3.x from completing successfully. - CPD
 - Fixed an issue where builds would fail on el 10 systems due to a missing dependency. - BB
 - Fixed rpm -V reporting false positives on RHEL for config, log, database, and service files. [GH#1299] - CPD
+- Fixed an issue where NCPA would fail to start when started without root privileges after the configured uid/gid had already been applied. [GH#1306] - CPD
+- Fixed root-only startup tasks (log file chown, temp file cleanup, directory creation) running when NCPA was not started as root, which could cause startup failures on non-root deployments. [GH#1306] - CPD
 - Several improvements to disk endpoint performance. [GH#1282] - BB
 
 **Removed**

--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -704,6 +704,20 @@ class Daemon():
     def set_uid_gid(self):
         """Drop root privileges"""
         self.logger.debug("Daemon - set_uid_gid()")
+
+        current_uid = os.getuid()
+        current_gid = os.getgid()
+        if current_uid == self.uid and current_gid == self.gid:
+            self.logger.debug(
+                "Already running as configured user/group (uid:%d, gid:%d), skipping privilege drop",
+                current_uid, current_gid)
+            return
+        if os.geteuid() != 0:
+            self.logger.warning(
+                "Not running as root (uid:%d, gid:%d); cannot drop to uid:%d gid:%d, skipping privilege drop",
+                current_uid, current_gid, self.uid, self.gid)
+            return
+
         # Get set of gids to set for OS groups
         gids = [ self.gid ]
         if self.username:

--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -557,8 +557,6 @@ class Daemon():
         signal.signal(signal.SIGTERM, self.on_sigterm)
         signal.signal(signal.SIGINT, self.on_sigterm)
 
-    def running_as_root(self):
-        return os.geteuid() == 0
 
     # ATTENTION - This function contains the infinite while loop that prevents
     # the process from exiting during normal operation
@@ -576,7 +574,7 @@ class Daemon():
         self.prepare_dirs()
 
         try:
-            if self.running_as_root():
+            if os.geteuid() == 0:
                 # Chown the installed passive log file while root still has control
                 # Since the listener file is used for the root and parent loggers, it is chowned
                 # during the setup_logger process
@@ -709,7 +707,7 @@ class Daemon():
             parent = os.path.dirname(fn)
             if not os.path.exists(parent):
                 os.makedirs(parent)
-                if self.running_as_root():
+                if os.geteuid() == 0:
                     self.chown(parent)
 
     def set_uid_gid(self):

--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -497,6 +497,10 @@ class Daemon():
         terminal has not been detached and the pid of the long-running
         process is not yet known.
         """
+        if os.geteuid() != 0:
+            self.logger.debug("Not running as root; skipping root_setup_tasks()")
+            return
+
         self.logger.debug("Daemon init - setup_root()")
 
         # We need to chown any temp files we wrote out as root (or any other user)
@@ -553,6 +557,9 @@ class Daemon():
         signal.signal(signal.SIGTERM, self.on_sigterm)
         signal.signal(signal.SIGINT, self.on_sigterm)
 
+    def running_as_root(self):
+        return os.geteuid() == 0
+
     # ATTENTION - This function contains the infinite while loop that prevents
     # the process from exiting during normal operation
     def start(self):
@@ -569,14 +576,17 @@ class Daemon():
         self.prepare_dirs()
 
         try:
-            # Chown the installed passive log file while root still has control
-            # Since the listener file is used for the root and parent loggers, it is chowned
-            # during the setup_logger process
-            if __SYSTEM__ == 'posix' and os.path.isfile(self.passive_logfile):
-                chown(self.config.get('general', 'uid'), self.config.get('general', 'gid'), self.passive_logfile)
+            if self.running_as_root():
+                # Chown the installed passive log file while root still has control
+                # Since the listener file is used for the root and parent loggers, it is chowned
+                # during the setup_logger process
+                if __SYSTEM__ == 'posix' and os.path.isfile(self.passive_logfile) and os.geteuid() == 0:
+                    chown(self.config.get('general', 'uid'), self.config.get('general', 'gid'), self.passive_logfile)
 
-            # Setup with root privileges
-            self.root_setup_tasks()
+                # Setup with root privileges
+                self.root_setup_tasks()
+            else:
+                self.logger.debug("Not running as root; skipping root-only startup tasks")
 
             # Drop permissions to specified user/group in ncpa.cfg
             self.set_uid_gid()
@@ -699,7 +709,8 @@ class Daemon():
             parent = os.path.dirname(fn)
             if not os.path.exists(parent):
                 os.makedirs(parent)
-                self.chown(parent)
+                if self.running_as_root():
+                    self.chown(parent)
 
     def set_uid_gid(self):
         """Drop root privileges"""
@@ -1237,8 +1248,11 @@ def chown(user_uid, user_gid, fn):
         try:
             os.chown(fn, uid, gid)
         except OSError as err:
+            if os.geteuid() != 0:
+                parent_logger.debug("Skipping chown(%s): not running as root", repr(fn))
+                return
             sys.exit("can't chown(%s, %d, %d): %s, %s" %
-            (repr(fn), uid, gid, err.errno, err.strerror))
+                     (repr(fn), uid, gid, err.errno, err.strerror))
 
 def setup_logger(config, loggerinstance, logfile):
     """Configure the logging module"""


### PR DESCRIPTION
## Summary

Fixes a regression where NCPA fails to start on systems where the init system has already dropped privileges (e.g. `sudo -u nagios` on Solaris/AIX, or systemd units with `User=` set).

Since 3.1.4, `set_uid_gid()` raises on `setgid`/`setuid` failures instead of only logging them. When NCPA is already running as the configured user, those calls fail with `Operation not permitted` and startup aborts.

This PR restores safe behavior for non-root starts while preserving strict error handling when NCPA is started as root and privilege drop fails unexpectedly.

Fixes #1306

## Changes

### Core fix (`set_uid_gid`)
- Skip privilege drop when current uid/gid already match the configured values
- Skip privilege drop when not running as root (`os.geteuid() != 0`), with a warning log

### Hardening (root-only startup tasks)
- Guard passive log `chown` and `root_setup_tasks()` in `Daemon.start()` behind a root check
- Add early return in `root_setup_tasks()` when not running as root
- Only `chown` newly created directories in `prepare_dirs()` when running as root
- Skip listener log `chown` in `setup_logger()` when not running as root
- Avoid `sys.exit()` in the global `chown()` helper when not running as root

## Test plan
- [x] Start NCPA as root via systemd (`systemctl start ncpa`) and confirm it drops to the configured uid/gid
- [x] Start NCPA as non-root user matching `ncpa.cfg` uid/gid (e.g. `sudo -u nagios -g nagios /usr/local/ncpa/ncpa --start`) and confirm startup succeeds
- [x] Start NCPA with a custom systemd unit using `User=nagios Group=nagios` and confirm startup succeeds
- [x] Confirm listener and passive logs are writable after startup in both root and non-root start scenarios
- [x] Confirm no `Operation not permitted` errors in logs when started with privileges already dropped