### PR TITLE
fix(aix): lock cryptography version due to issues with newest version

### DIFF
--- a/build/aix/setup.sh
+++ b/build/aix/setup.sh
@@ -225,5 +225,5 @@ if [ -n "$VENV_MANAGER" ] && [ -x "$VENV_MANAGER" ]; then
 
     # Install cryptography with the correct compiler flags
     export CC="gcc -maix64"
-    $PYTHONBIN -m pip install cryptography
+    $PYTHONBIN -m pip install cryptography==48.0.1
 fi 


### PR DESCRIPTION
Not adding a changelog entry since this is an additional AIX build fix, which already has a changelog entry this release.