### PR TITLE
Update deprecated datetime utcnow() method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 
 **Updates**
 
+- Replaced deprecated datetime.utcnow() usage in certificate generation and Windows event log handling to improve compatibility with Python 3.12+. - CPD
 - Updated Windows builds to use OpenSSL version 3.0.21 to resolve CVEs and improve compatibility. [GH#1397] - CPD
 - Updated Windows builds to use Python version 3.13.14. - CPD
 

--- a/agent/listener/certificate.py
+++ b/agent/listener/certificate.py
@@ -1,7 +1,7 @@
 import os
 import socket
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ipaddress import IPv4Address
 
 try:
@@ -84,9 +84,9 @@ def _create_cert_with_cryptography(target_cert, target_key):
     ).serial_number(
         int(time.time())
     ).not_valid_before(
-        datetime.utcnow()
+        datetime.now(timezone.utc)
     ).not_valid_after(
-        datetime.utcnow() + timedelta(days=3650)  # 10 years
+        datetime.now(timezone.utc) + timedelta(days=3650)  # 10 years
     ).add_extension(
         x509.KeyUsage(
             digital_signature=True,

--- a/agent/listener/windowslogs.py
+++ b/agent/listener/windowslogs.py
@@ -59,6 +59,16 @@ import platform
 from ncpa import listener_logger as logging
 
 
+def utc_now_naive():
+    """Return a naive UTC datetime for legacy win32 event timestamp comparisons."""
+    return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+
+
+def local_utc_offset_seconds():
+    """Return seconds between local time and UTC (equivalent to utcnow() - now())."""
+    return (datetime.datetime.now(datetime.timezone.utc) - datetime.datetime.now().astimezone()).total_seconds()
+
+
 class WindowsLogsNode(listener.nodes.LazyNode):
 
     global stdLogs
@@ -625,7 +635,7 @@ def normalize_xml_event(row, name):
         timezone_offset = datetime.timedelta(0)
     
     rDate -= timezone_offset
-    timeDiffSec=(datetime.datetime.utcnow() - datetime.datetime.now()).total_seconds()
+    timeDiffSec = local_utc_offset_seconds()
     timeLocal = str(rDate+datetime.timedelta(seconds=-timeDiffSec))
     safe_log['time_generated'] = timeLocal
     return safe_log
@@ -668,9 +678,9 @@ def get_event_logs(server, name, filters):
         logs = []
         try:
             logged_after = filters['logged_after']
-            logged_after = datetime.datetime.utcnow() - logged_after
+            logged_after = utc_now_naive() - logged_after
         except KeyError:
-            logged_after = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            logged_after = utc_now_naive() - datetime.timedelta(days=1)
         try:
             while True:
                 events = win32evtlog.EvtNext(handle, 100)
@@ -776,7 +786,7 @@ def tail_method(last_ts, server=None, *args, **kwargs):
     logs = get_event_logs(server, name, filters)
     newest_ts = last_ts
     non_dup_logs = []
-    timeDiffSec=(datetime.datetime.utcnow() - datetime.datetime.now()).total_seconds()
+    timeDiffSec = local_utc_offset_seconds()
 
     for log in logs:
         if name in stdLogs:


### PR DESCRIPTION
I discovered this when I was running the NCPA unit tests. We were getting the following warning messages:

```
====================================================================== warnings summary ======================================================================
test/test_certificate.py::TestCertificate::test_create_self_signed_certificate_empty_file
test/test_certificate.py::TestCertificate::test_create_self_signed_certificate_nonexisting_file
  /root/ncpa/test/../agent/listener/certificate.py:87: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    datetime.utcnow()

test/test_certificate.py::TestCertificate::test_create_self_signed_certificate_empty_file
test/test_certificate.py::TestCertificate::test_create_self_signed_certificate_nonexisting_file
  /root/ncpa/test/../agent/listener/certificate.py:89: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    datetime.utcnow() + timedelta(days=3650)  # 10 years

```
Seemed like a good time to go ahead and preemptively update these before they are abruptly removed in a future Python release.