### PR TITLE
Fix for test_ncpacheck unit test failures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 - Fixed rpm -V reporting false positives on RHEL for config, log, database, and service files. [GH#1299] - CPD
 - Fixed an issue where NCPA would fail to start when started without root privileges after the configured uid/gid had already been applied. [GH#1306] - CPD
 - Fixed root-only startup tasks (log file chown, temp file cleanup, directory creation) which could cause startup failures on non-root deployments. [GH#1306] - CPD
+- Resolved test_ncpacheck unit test failures due to the backup_community_string config option not being set in the test configuration. - CPD
 - Several improvements to disk endpoint performance. [GH#1282] - BB
 
 **Removed**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Changelog
 
 **Removed**
 
-- Removed pyOenSSL from the AIX build dependency list as it was not being used and was causing build issues. - CPD
+- Removed pyOpenSSL from the AIX build dependency list as it was not being used and was causing build issues. - CPD
 
 **Updates**
 

--- a/agent/listener/certificate.py
+++ b/agent/listener/certificate.py
@@ -1,7 +1,7 @@
 import os
 import socket
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ipaddress import IPv4Address
 
 try:
@@ -84,9 +84,9 @@ def _create_cert_with_cryptography(target_cert, target_key):
     ).serial_number(
         int(time.time())
     ).not_valid_before(
-        datetime.utcnow()
+        datetime.now(timezone.utc)
     ).not_valid_after(
-        datetime.utcnow() + timedelta(days=3650)  # 10 years
+        datetime.now(timezone.utc) + timedelta(days=3650)  # 10 years
     ).add_extension(
         x509.KeyUsage(
             digital_signature=True,

--- a/test/test_ncpacheck.py
+++ b/test/test_ncpacheck.py
@@ -17,6 +17,7 @@ class TestNCPACheck(unittest.TestCase):
         self.config = configparser.ConfigParser()
         self.config.add_section('api')
         self.config.set('api', 'community_string', 'mytoken')
+        self.config.set('api', 'backup_community_string', '')
 
     def test_get_api_url_from_instruction(self):
         instruction = 'cpu/percent --warning 10 --critical=11'

--- a/test/test_nrdphandler.py
+++ b/test/test_nrdphandler.py
@@ -22,6 +22,7 @@ class TestNRDPHandler(TestCase):
         self.config.set('passive checks', 'TESTING|TESTING', '/cpu/count')
         self.config.add_section('api')
         self.config.set('api', 'community_string', 'mytoken')
+        self.config.set('api', 'backup_community_string', '')
         self.n = passive.nrdp.Handler(self.config)
 
     def test_guess_hostname(self):


### PR DESCRIPTION
This fix resolves the test_ncpacheck unit test failures due to the backup_community_string config option not being set in the test configuration.