### PR TITLE
feat(ssl): add ssl_max_version config option to allow custom ssl_ciphers (on TLSv1_2) to work again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 - Enabled continuous integration via GitHub Actions across Linux, Windows, and macOS. - CPD
 - Added gui_session_timeout config option in the [listener] section to automatically log out inactive web GUI sessions after a configurable period (default: 1 hour). - CPD
+- Added ssl_max_version config option in the [listener] section to specify the maximum TLS version allowed for incoming connections. - CPD
 
 **Bug Fixes**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 - Enabled continuous integration via GitHub Actions across Linux, Windows, and macOS. - CPD
 - Added gui_session_timeout config option in the [listener] section to automatically log out inactive web GUI sessions after a configurable period (default: 1 hour). - CPD
-- Added ssl_max_version config option in the [listener] section to specify the maximum TLS version allowed for incoming connections. - CPD
+- Added ssl_max_version config option in the [listener] section to specify the maximum TLS version allowed for incoming connections. [GH#1417] - CPD
 
 **Bug Fixes**
 

--- a/agent/etc/ncpa.cfg
+++ b/agent/etc/ncpa.cfg
@@ -100,22 +100,29 @@ default_units = Gi
 # ip =
 # port =
 
-#
-# SSL connection, certificate and ciphers config (if an SSL option is not available on some older
-# operating systems it will default back to TLSv1_2)
-# ssl_version options: TLSv1_2, TLSv1_3
-# Default: ssl_version = TLSv1_2
-# Default: certificate = adhoc
-#
+# -------------------------------
+# SSL / TLS Configuration
+# -------------------------------
+
+# Minimum SSL protocol version
+# - Options: TLSv1_2, TLSv1_3
+# - Default: TLSv1_2
 ssl_version = TLSv1_2
+
+# Server certificate path or 'adhoc'
+# - Default: adhoc
 certificate = adhoc
 
-# ssl_max_version options: TLSv1_2, TLSv1_3 (leave blank to allow the highest supported version)
-# Default: ssl_max_version =
+# Maximum SSL protocol version
+# - Options: TLSv1_2, TLSv1_3 (leave blank for highest supported)
+# - Note: Must be set to TLSv1_2 if using custom 'ssl_ciphers'
+# - Default: (blank)
+# ssl_max_version =
 
-# ssl_ciphers: sets a list of accepted SSL ciphers for TLSv1.2 and below using the format <cipher>:<cipher>:<cipher>, e.g., AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:CAMELLIA256-SHA
-# Default: ssl_ciphers =
-#
+# Accepted SSL/TLS ciphers for TLSv1_2 (Ignored for TLSv1_3)
+# - Format: <cipher>:<cipher>:<cipher> (e.g., AES256-GCM-SHA384:AES256-SHA256)
+# - Default: (blank)
+# ssl_ciphers =
 
 #
 # Listener logging file level, location, and the PID location

--- a/agent/etc/ncpa.cfg
+++ b/agent/etc/ncpa.cfg
@@ -110,7 +110,10 @@ default_units = Gi
 ssl_version = TLSv1_2
 certificate = adhoc
 
-# ssl_ciphers: sets a list of accepted SSL ciphers using the format <cipher>:<cipher>:<cipher>, e.g., AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:CAMELLIA256-SHA
+# ssl_max_version options: TLSv1_2, TLSv1_3 (leave blank to allow the highest supported version)
+# Default: ssl_max_version =
+
+# ssl_ciphers: sets a list of accepted SSL ciphers for TLSv1.2 and below using the format <cipher>:<cipher>:<cipher>, e.g., AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:CAMELLIA256-SHA
 # Default: ssl_ciphers =
 #
 

--- a/agent/etc/ncpa.cfg.sample
+++ b/agent/etc/ncpa.cfg.sample
@@ -100,19 +100,29 @@ default_units = Gi
 # ip =
 # port =
 
-#
-# SSL connection, certificate and ciphers config (if an SSL option is not available on some older
-# operating systems it will default back to TLSv1_2)
-# ssl_version options: TLSv1_2, TLSv1_3
-# Default: ssl_version = TLSv1_2
-# Default: certificate = adhoc
-#
+# -------------------------------
+# SSL / TLS Configuration
+# -------------------------------
+
+# Minimum SSL protocol version
+# - Options: TLSv1_2, TLSv1_3
+# - Default: TLSv1_2
 ssl_version = TLSv1_2
+
+# Server certificate path or 'adhoc'
+# - Default: adhoc
 certificate = adhoc
 
-# ssl_ciphers: sets a list of accepted SSL ciphers using the format <cipher>:<cipher>:<cipher>, e.g., AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:CAMELLIA256-SHA
-# Default: ssl_ciphers =
-#
+# Maximum SSL protocol version
+# - Options: TLSv1_2, TLSv1_3 (leave blank for highest supported)
+# - Note: Must be set to TLSv1_2 if using custom 'ssl_ciphers'
+# - Default: (blank)
+# ssl_max_version =
+
+# Accepted SSL/TLS ciphers for TLSv1_2 (Ignored for TLSv1_3)
+# - Format: <cipher>:<cipher>:<cipher> (e.g., AES256-GCM-SHA384:AES256-SHA256)
+# - Default: (blank)
+# ssl_ciphers =
 
 #
 # Listener logging file level, location, and the PID location

--- a/agent/listener/static/help/configuration.html
+++ b/agent/listener/static/help/configuration.html
@@ -187,6 +187,17 @@
                             </tr>
                             <tr>
                                 <td></td>
+                                <th>ssl_max_version</th>
+                                <td></td>
+                                <td>
+                                    Set the maximum SSL protocol version to allow for connecting to the HTTPS server.
+                                    <br>
+                                    Note: Must be set to TLSv1_2 if using custom 'ssl_ciphers'
+                                    <div><b>Options:</b> <em>TLSv1_2</em>, or <em>TLSv1_3</em></div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td></td>
                                 <th>ssl_ciphers</th>
                                 <td></td>
                                 <td>

--- a/agent/listener/templates/admin/listener.html
+++ b/agent/listener/templates/admin/listener.html
@@ -65,6 +65,7 @@ $(document).ready(function() {
                         <label class="control-label col-sm-4 col-md-3 col-lg-2 col-xl-2">SSL Max Version</label>
                         <div class="col-sm-6 col-md-4 col-lg-3 col-xl-1">
                             <select class="form-control" name="ssl_max_version">
+                                <option value=""{% if not sectioncfg['ssl_max_version'] %} selected{% endif %}></option>
                                 <option value="TLSv1_2"{% if sectioncfg['ssl_max_version'] == 'TLSv1_2' %} selected{% endif %}>TLSv1.2</option>
                                 <option value="TLSv1_3"{% if sectioncfg['ssl_max_version'] == 'TLSv1_3' %} selected{% endif %}>TLSv1.3</option>
                             </select>

--- a/agent/listener/templates/admin/listener.html
+++ b/agent/listener/templates/admin/listener.html
@@ -52,11 +52,21 @@ $(document).ready(function() {
                     </div>
 
                     <div class="form-group">
-                        <label class="control-label col-sm-4 col-md-3 col-lg-2 col-xl-2">SSL Version</label>
+                        <label class="control-label col-sm-4 col-md-3 col-lg-2 col-xl-2">SSL Version (min)</label>
                         <div class="col-sm-6 col-md-4 col-lg-3 col-xl-1">
                             <select class="form-control" name="ssl_version">
                                 <option value="TLSv1_2"{% if sectioncfg['ssl_version'] == 'TLSv1_2' %} selected{% endif %}>TLSv1.2</option>
                                 <option value="TLSv1_3"{% if sectioncfg['ssl_version'] == 'TLSv1_3' %} selected{% endif %}>TLSv1.3</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="control-label col-sm-4 col-md-3 col-lg-2 col-xl-2">SSL Max Version</label>
+                        <div class="col-sm-6 col-md-4 col-lg-3 col-xl-1">
+                            <select class="form-control" name="ssl_max_version">
+                                <option value="TLSv1_2"{% if sectioncfg['ssl_max_version'] == 'TLSv1_2' %} selected{% endif %}>TLSv1.2</option>
+                                <option value="TLSv1_3"{% if sectioncfg['ssl_max_version'] == 'TLSv1_3' %} selected{% endif %}>TLSv1.3</option>
                             </select>
                         </div>
                     </div>

--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -145,6 +145,7 @@ cfg_defaults = {
                 'ip': address,
                 'port': '5693',
                 'ssl_version': 'TLSv1_2',
+                'ssl_max_version': 'None',
                 'certificate': 'adhoc',
                 'ssl_ciphers': 'None',
                 'logfile': 'var/log/ncpa_listener.log',
@@ -286,6 +287,7 @@ class Listener(Base):
 
                 # Get the SSL version from the config and set it on the SSL context
                 ssl_str_version = self.config.get('listener', 'ssl_version')
+                ssl_max_version = self.config.get('listener', 'ssl_max_version')
 
                 # TLSv1_3 requires special handling since it doesn't use the PROTOCOL_ constant like previous versions, 
                 # and instead uses the minimum_version and maximum_version settings on the SSL context. 
@@ -299,6 +301,24 @@ class Listener(Base):
                     logger.warning('Unsupported SSL version specified in config: %s. Defaulting to TLSv1_2.', ssl_str_version)
                     ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
                 logger.debug('Using TLS version %s', ssl_str_version)
+
+                # Set the maximum SSL version
+                if ssl_max_version not in ('None', ''):
+                    if ssl_max_version == 'TLSv1_3':
+                        logger.info('Configuring TLSv1_3 as maximum version')
+                        ssl_context.maximum_version = ssl.TLSVersion.TLSv1_3
+                    elif ssl_max_version == 'TLSv1_2':
+                        logger.info('Configuring TLSv1_2 as maximum version')
+                        ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
+                    else:
+                        logger.warning('Unsupported ssl_max_version specified in config: %s. Ignoring.', ssl_max_version)
+                    if ssl_context.minimum_version > ssl_context.maximum_version:
+                        logger.warning(
+                            'ssl_version (%s) is higher than ssl_max_version (%s). Using ssl_max_version for both.',
+                            ssl_str_version,
+                            ssl_max_version,
+                        )
+                        ssl_context.minimum_version = ssl_context.maximum_version
 
                 # Get the certificate settings from the config - if it's set to 'adhoc', we'll create a self-signed cert, 
                 # otherwise we'll use the provided cert and key files (which should be comma-separated in the config)

--- a/agent/ncpa.py
+++ b/agent/ncpa.py
@@ -283,7 +283,6 @@ class Listener(Base):
                 else:
                     logger.debug("run() - ssl_str_ciphers: %s", ssl_str_ciphers)
                     ssl_context.set_ciphers(ssl_str_ciphers)
-                logger.debug("ssl_str_ciphers: %s", ssl_str_ciphers)
 
                 # Get the SSL version from the config and set it on the SSL context
                 ssl_str_version = self.config.get('listener', 'ssl_version')


### PR DESCRIPTION
## Summary

This PR adds configuration options for managing TLS/SSL maximum versions. By setting the tls_max_version to TLSv1_2, users will once again be able to use the custom 'ssl_ciphers' option.

TLS 1.3 cipher suites cannot be changed, disabled, or configured through standard Python methods because the underlying SSL_CTX_set_ciphersuites() wrapper has not been implemented in CPython.

Closes #1417.

## Changes

- Added ssl_max_version configuration option: Allows setting the maximum allowed SSL/TLS version (TLSv1_2 or TLSv1_3), with an option to leave it blank to automatically leverage the highest supported version.
- Documentation & Config Updates: Cleaned up and updated configuration file comments to clearly explain the interaction between ssl_max_version, ssl_ciphers, and TLS version fallbacks.

## Test Plan

- [x] Verified configuration parsing for ssl_max_version and custom ssl_ciphers.
- [x] Confirmed expected behavior when ssl_max_version is constrained to TLSv1_2 for cipher customization.
- [x] Use SSL cipher_scan shell script to confirm only specified ssl_ciphers are enabled.