### PR TITLE
fix(linux): prefer systemctl over service in RPM preinstall

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Multi-OS Python Matrix
 
 on:
   push:
-    branches: [ 'dev-v3*' ]
+    branches: [ 'dev-v3*', 'cpd-linux-install-stop-messagees' ]
 
 jobs:
   # ------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 **Bug Fixes**
 
 - Fixed a macOS installation issue caused by an xattr check error on Python 3.14 builds. - CPD
+- Fixed Linux RPM install/upgrade running ``service --status-all`` even when systemd is available, which could trigger unrelated SysV init scripts and cause production impact. [GH#1361] - CPD
 - Fixed multiple invalid escape sequences in the listener config/passive check GUI code that caused Python SyntaxWarnings and could break sed-based config updates on Linux. - CPD
 
 **Updates**

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -126,12 +126,8 @@ else
 fi
 
 %post
-if [ -e /etc/init.d/ncpa_listener ]; then
-    rm -f /etc/init.d/ncpa_listener
-fi
-if [ -e /etc/init.d/ncpa_passive ]; then
-    rm -f /etc/init.d/ncpa_passive
-fi
+# Leave /etc/init.d/ncpa_{listener,passive} for RPM to remove on 2.x->3.x
+# upgrades; deleting them here races old-package file erasure.
 
 if [ -z $RPM_INSTALL_PREFIX ]
 then

--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -55,32 +55,37 @@ sed -i 's|_BASEDIR_|/usr/local/ncpa|' %{buildroot}/usr/lib/systemd/system/ncpa.s
 rm -rf %{buildroot}
 
 %pre
-if which chkconfig &> /dev/null; then
-    echo "Try to stop services with chkconfig"
-    [ -f /usr/local/ncpa/ncpa_listener ] && /usr/local/ncpa/ncpa_listener --stop &> /dev/null
-    [ -f /usr/local/ncpa/ncpa_passive ] && /usr/local/ncpa/ncpa_passive --stop &> /dev/null
-    chkconfig ncpa_listener && chkconfig --del ncpa_listener &> /dev/null
-    chkconfig ncpa_passive && chkconfig --del ncpa_passive &> /dev/null
-fi
-if command -v systemctl &> /dev/null
-then
-    echo "Try to stop services with systemctl"
-    systemctl list-units --full -all | grep -Fq 'ncpa_listener.service' && systemctl stop ncpa_listener &> /dev/null || true
-    systemctl list-units --full -all | grep -Fq 'ncpa_passive.service' && systemctl stop ncpa_passive &> /dev/null || true
+# Stop existing NCPA services before install/upgrade.
+# Prefer systemd; fall back to SysV. Avoid echoing status lines that look like errors.
+if command -v systemctl &> /dev/null; then
+    if systemctl list-units --full -all 2>/dev/null | grep -Fq 'ncpa_listener.service'; then
+        systemctl stop ncpa_listener &> /dev/null || true
+    fi
+    if systemctl list-units --full -all 2>/dev/null | grep -Fq 'ncpa_passive.service'; then
+        systemctl stop ncpa_passive &> /dev/null || true
+    fi
     systemctl stop ncpa &> /dev/null || true
-fi
-if command -v service &> /dev/null
-then
-    echo "Try to stop services with service"
-    service --status-all 2>&1 | grep -Fq 'ncpa_listener' && service ncpa_listener stop &> /dev/null || true
-    service --status-all 2>&1 | grep -Fq 'ncpa_passive' && service ncpa_passive stop &> /dev/null || true
+elif command -v service &> /dev/null; then
+    if service --status-all 2>&1 | grep -Fq 'ncpa_listener'; then
+        service ncpa_listener stop &> /dev/null || true
+    fi
+    if service --status-all 2>&1 | grep -Fq 'ncpa_passive'; then
+        service ncpa_passive stop &> /dev/null || true
+    fi
     service ncpa stop &> /dev/null || true
 fi
 
+# Clean up legacy NCPA 2 SysV registrations (safe no-ops when absent)
+if which chkconfig &> /dev/null; then
+    [ -f /usr/local/ncpa/ncpa_listener ] && /usr/local/ncpa/ncpa_listener --stop &> /dev/null || true
+    [ -f /usr/local/ncpa/ncpa_passive ] && /usr/local/ncpa/ncpa_passive --stop &> /dev/null || true
+    chkconfig ncpa_listener && chkconfig --del ncpa_listener &> /dev/null || true
+    chkconfig ncpa_passive && chkconfig --del ncpa_passive &> /dev/null || true
+fi
 
 if which update-rc.d >/dev/null 2>&1; then
-    update-rc.d -f ncpa_listener remove
-    update-rc.d -f ncpa_passive remove
+    update-rc.d -f ncpa_listener remove &> /dev/null || true
+    update-rc.d -f ncpa_passive remove &> /dev/null || true
 fi
 
 if ! getent group nagios &> /dev/null


### PR DESCRIPTION
## Summary
- Prefer `systemctl` over `service` in the Linux RPM `%pre` script so install/upgrade no longer runs `service --status-all` on systemd systems
- Removes noisy "Try to stop services..." messages during install
- Keeps SysV/`service` as a fallback only when systemd is unavailable
- Stop deleting /etc/init.d/ncpa_listener and ncpa_passive in %post so RPM can erase them during 2.x→3.x upgrades without "remove failed" warnings.

Fixes #1361

## Test plan
- [x] Fresh install on RHEL/CentOS with systemd — no `service --status-all` side effects; NCPA starts normally
- [x] Upgrade from NCPA 2.x to 3.x on RHEL/Oracle 8 — old listener/passive services stop cleanly; new `ncpa` service starts
- [x] Confirm upgrade from 2.x to 3. no longer shows warning messages that read remove failed: No such file or directory
- [x] Upgrade from NCPA 3.x to newer 3.x — service stops and restarts without install noise
- [x] Confirm install output no longer shows "Try to stop services with systemctl/service"