### PR TITLE
Add /api/system/os_release endpoint for Linux distribution info

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Multi-OS Python Matrix
 
 on:
   push:
-    branches: [ 'dev-v3*', 'cpd-linux-install-stop-messagees' ]
+    branches: [ 'dev-v3*', 'cpd-linux-install-stop-messagees', 'cpd-detailed-os-release-info' ]
 
 jobs:
   # ------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 ==================
 **Added**
 
+- Added /api/system/os_release endpoint exposing Linux distribution fields from /etc/os-release (name, id, pretty_name, version_id, etc.). [GH#1358] - CPD
 - Enabled continuous integration via GitHub Actions across Linux, Windows, and macOS. - CPD
 - Added gui_session_timeout config option in the [listener] section to automatically log out inactive web GUI sessions after a configurable period (default: 1 hour). - CPD
 - Added ssl_max_version config option in the [listener] section to specify the maximum TLS version allowed for incoming connections. [GH#1417] - CPD

--- a/agent/listener/psapi.py
+++ b/agent/listener/psapi.py
@@ -267,6 +267,77 @@ def get_timezone():
     return zones, ""
 
 
+# Stable subset of /etc/os-release keys exposed under /api/system/os_release
+OS_RELEASE_FIELDS = (
+    ("NAME", "name"),
+    ("ID", "id"),
+    ("PRETTY_NAME", "pretty_name"),
+    ("VERSION", "version"),
+    ("VERSION_ID", "version_id"),
+    ("VERSION_CODENAME", "version_codename"),
+    ("ID_LIKE", "id_like"),
+)
+
+
+def parse_os_release_file(contents):
+    """Parse os-release file contents into a dict of KEY -> value."""
+    data = {}
+    for line in contents.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+            value = (
+                value.replace("\\\"", '"')
+                .replace("\\'", "'")
+                .replace("\\\\", "\\")
+                .replace("\\$", "$")
+                .replace("\\`", "`")
+            )
+        data[key] = value
+    return data
+
+
+def read_os_release():
+    """Read distribution info from os-release. Returns {} when unavailable."""
+    try:
+        return dict(platform.freedesktop_os_release())
+    except (AttributeError, OSError):
+        pass
+
+    for path in ("/etc/os-release", "/usr/lib/os-release"):
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                return parse_os_release_file(handle.read())
+        except (OSError, IOError):
+            continue
+    return {}
+
+
+def get_os_release_node(data=None):
+    """Build the system/os_release node, or None if os-release is unavailable."""
+    if data is None:
+        data = read_os_release()
+    if not data:
+        return None
+
+    children = []
+    for src_key, dest_key in OS_RELEASE_FIELDS:
+        value = data.get(src_key)
+        if value:
+            children.append(
+                RunnableNode(dest_key, method=lambda v=value: (v, ""))
+            )
+
+    if not children:
+        return None
+    return ParentNode("os_release", children=children)
+
+
 def get_system_node():
     logging.debug("get_system_node() was called")
     sys_system = RunnableNode("system", method=lambda: (platform.uname()[0], ""))
@@ -279,21 +350,25 @@ def get_system_node():
     sys_agent = RunnableNode("agent_version", method=lambda: (__VERSION__, ""))
     sys_time = RunnableNode("time", method=lambda: (time.time(), ""))
     sys_timezone = RunnableNode("timezone", method=get_timezone)
-    return ParentNode(
-        "system",
-        children=[
-            sys_node,
-            sys_machine,
-            sys_uptime,
-            sys_version,
-            sys_time,
-            sys_release,
-            sys_timezone,
-            sys_agent,
-            sys_system,
-            sys_processor,
-        ],
-    )
+
+    children = [
+        sys_node,
+        sys_machine,
+        sys_uptime,
+        sys_version,
+        sys_time,
+        sys_release,
+        sys_timezone,
+        sys_agent,
+        sys_system,
+        sys_processor,
+    ]
+
+    os_release = get_os_release_node()
+    if os_release is not None:
+        children.append(os_release)
+        
+    return ParentNode("system", children=children)
 
 
 def get_cpu_node(cpu_interval=0.5):

--- a/agent/listener/static/help/api.html
+++ b/agent/listener/static/help/api.html
@@ -830,8 +830,17 @@
                     <a name="api-modules-system"></a>
                     <h4>system</h4>
                     <p>This module is used for getting information about the system that NCPA is running on and the agent version. It doesn't currently have the ability to perform many checks. However, we do use the output of the <code>system/agent_version</code> check to give the default <code>__HOST__</code> service an output in passive checks and for the host in active checks created by running the Nagios XI NCPA config wizard.</p>
+                    <p>On Linux systems that provide <code>/etc/os-release</code> (or <code>/usr/lib/os-release</code>), the <code>system/os_release</code> node exposes distribution identity fields such as <code>name</code>, <code>id</code>, <code>pretty_name</code>, <code>version_id</code>, <code>version</code>, <code>version_codename</code>, and <code>id_like</code>. This node is omitted on platforms where os-release data is unavailable.</p>
                     <p><em>You cannot use any special parameters on this module. This module is just for getting system information.</em></p>
-
+                    <pre>https://localhost:5693/api/system/os_release?token=mytoken</pre>
+                    <pre>{
+    "os_release": {
+        "name": "Red Hat Enterprise Linux",
+        "id": "rhel",
+        "pretty_name": "Red Hat Enterprise Linux 9.2 (Plow)",
+        "version_id": "9.2"
+    }
+}</pre>
                     <a name="api-modules-plugins"></a>
                     <h4>plugins</h4>
                     <p>This module will show you a list of all available plugins (that are in the directory defined <code>plugin_path</code>) and let's you run them.</p>

--- a/test/test_psapi.py
+++ b/test/test_psapi.py
@@ -69,6 +69,80 @@ class TestPSApi(unittest.TestCase):
         if_node = listener.psapi.get_system_node()
         self.assertIsInstance(if_node, listener.nodes.ParentNode)
 
+    def test_parse_os_release_file(self):
+        contents = (
+            'NAME="Red Hat Enterprise Linux"\n'
+            "ID=rhel\n"
+            'PRETTY_NAME="Red Hat Enterprise Linux 9.2 (Plow)"\n'
+            'VERSION_ID="9.2"\n'
+            "# comment\n"
+            "ID_LIKE=\"fedora\"\n"
+        )
+        data = listener.psapi.parse_os_release_file(contents)
+        self.assertEqual(data["NAME"], "Red Hat Enterprise Linux")
+        self.assertEqual(data["ID"], "rhel")
+        self.assertEqual(data["PRETTY_NAME"], "Red Hat Enterprise Linux 9.2 (Plow)")
+        self.assertEqual(data["VERSION_ID"], "9.2")
+        self.assertEqual(data["ID_LIKE"], "fedora")
+        self.assertNotIn("# comment", data)
+
+    def test_get_os_release_node_builds_children(self):
+        data = {
+            "NAME": "Ubuntu",
+            "ID": "ubuntu",
+            "PRETTY_NAME": "Ubuntu 22.04.3 LTS",
+            "VERSION_ID": "22.04",
+            "VERSION_CODENAME": "jammy",
+            "ID_LIKE": "debian",
+        }
+        node = listener.psapi.get_os_release_node(data)
+        self.assertIsInstance(node, listener.nodes.ParentNode)
+        self.assertEqual(node.name, "os_release")
+        self.assertIn("name", node.children)
+        self.assertIn("id", node.children)
+        self.assertIn("pretty_name", node.children)
+        self.assertIn("version_id", node.children)
+        self.assertIn("version_codename", node.children)
+        self.assertIn("id_like", node.children)
+
+        walked = node.walk()
+        self.assertEqual(
+            walked,
+            {
+                "os_release": {
+                    "name": "Ubuntu",
+                    "id": "ubuntu",
+                    "pretty_name": "Ubuntu 22.04.3 LTS",
+                    "version_id": "22.04",
+                    "version_codename": "jammy",
+                    "id_like": "debian",
+                }
+            },
+        )
+
+    def test_get_os_release_node_returns_none_when_unavailable(self):
+        self.assertIsNone(listener.psapi.get_os_release_node({}))
+
+    @patch("listener.psapi.get_os_release_node")
+    def test_get_system_node_includes_os_release(self, mock_get_os_release_node):
+        mock_get_os_release_node.return_value = listener.nodes.ParentNode(
+            "os_release",
+            children=[
+                listener.nodes.RunnableNode(
+                    "pretty_name", method=lambda: ("Test OS", "")
+                )
+            ],
+        )
+        system_node = listener.psapi.get_system_node()
+        self.assertIn("os_release", system_node.children)
+
+    @patch("listener.psapi.get_os_release_node", return_value=None)
+    def test_get_system_node_omits_os_release_when_unavailable(
+        self, mock_get_os_release_node
+    ):
+        system_node = listener.psapi.get_system_node()
+        self.assertNotIn("os_release", system_node.children)
+
     def test_get_cpu_node(self):
         cpu_node = listener.psapi.get_cpu_node()
         self.assertIsInstance(cpu_node, listener.nodes.ParentNode)


### PR DESCRIPTION
## Summary
- Expose Linux `/etc/os-release` fields under `/api/system/os_release` for inventory and compliance use cases
- Return stable lowercase keys (`name`, `id`, `pretty_name`, `version`, `version_id`, `version_codename`, `id_like`) when available
- Omit the node on platforms where os-release data is unavailable

Closes #1358

## Test plan
- [x] On Linux, `GET /api/system/os_release` returns expected distro fields from `/etc/os-release`
- [x] Leaf endpoints work (e.g. `/api/system/os_release/pretty_name`)
- [x] On Windows/macOS (or systems without os-release), `/api/system` does not include `os_release`
- [x] Run `pytest -v` and confirm there are no test failures or warnings
- [x] Confirm API help docs show the new `system/os_release` example